### PR TITLE
Refactor route config functions and fix parameter is…

### DIFF
--- a/src/formatConfig.ts
+++ b/src/formatConfig.ts
@@ -1,7 +1,8 @@
+import { removeQueryArea } from "./generator.ts";
 import { Symbols } from "./symbols.ts";
 import type {
   FlatRouteConfig,
-  FlattenRouteConfig,
+  FormatRouteConfig,
   RouteConfig,
 } from "./types.ts";
 
@@ -37,13 +38,14 @@ import type {
  * @param result - The result object, used internally during recursion.
  * @returns The flattened route configuration.
  */
-export function flattenRouteConfig<Config extends RouteConfig>(
+export function formatRouteConfig<Config extends RouteConfig>(
   routeConfig: Config,
   parentPath = "",
   result: FlatRouteConfig = {},
-): FlattenRouteConfig<Config> {
+): FormatRouteConfig<Config> {
   for (const parentRouteId in routeConfig) {
     const route = routeConfig[parentRouteId];
+
     const currentPath = route.path;
 
     const fullPath = parentPath + currentPath;
@@ -51,7 +53,12 @@ export function flattenRouteConfig<Config extends RouteConfig>(
     result[parentRouteId] = fullPath;
 
     if (route.children) {
-      const children = flattenRouteConfig(route.children, fullPath);
+      const parentPathToJoinChildren = removeQueryArea(fullPath);
+
+      const children = formatRouteConfig(
+        route.children,
+        parentPathToJoinChildren,
+      );
 
       for (const childRouteId in children) {
         const childFullRouteId =
@@ -61,5 +68,5 @@ export function flattenRouteConfig<Config extends RouteConfig>(
       }
     }
   }
-  return result as FlattenRouteConfig<Config>;
+  return result as FormatRouteConfig<Config>;
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -79,7 +79,7 @@ function isRootPath(path: string): boolean {
   return path === "/";
 }
 
-function removeQueryArea(path: string): string {
+export function removeQueryArea(path: string): string {
   const searchAreaStartIndex = path.indexOf(
     Symbols.PathSeparater + Symbols.Search,
   );
@@ -111,9 +111,11 @@ function replaceParams(
 
     const paramValue = params[paramName];
 
-    return paramValue
-      ? Symbols.PathSeparater + encodeURIComponent(paramValue)
-      : "";
+    if (!paramValue && paramValue !== false) {
+      return "";
+    }
+
+    return Symbols.PathSeparater + encodeURIComponent(paramValue);
   });
 }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,9 +1,9 @@
-import { flattenRouteConfig } from "./flattenConfig.ts";
+import { formatRouteConfig } from "./formatConfig.ts";
 import { createLinkGenerator } from "./generator.ts";
 import type {
   DefaultParameterType,
   ExtractRouteData,
-  FlattenRouteConfig,
+  FormatRouteConfig,
   LinkGenerator,
   Parameter,
   ParameterAcceptValue,
@@ -15,8 +15,8 @@ export {
   createLinkGenerator,
   type DefaultParameterType,
   type ExtractRouteData,
-  type FlattenRouteConfig,
-  flattenRouteConfig,
+  type FormatRouteConfig,
+  formatRouteConfig,
   type LinkGenerator,
   type Parameter,
   type ParameterAcceptValue,


### PR DESCRIPTION
Refactor route config functions and fix parameter issues

- Renamed function from `flattenRouteConfig` to `formatRouteConfig`.
- Renamed file from `flattenRouteConfig.ts` to `formatRouteConfig.ts`.
- Changed implementation of the function: The `flattenRouteConfig` function previously concatenated parent route paths directly to child route paths. The revised `formatRouteConfig` function now removes search parameters from the parent route's path before merging it with the child route's path.
- Updated types: Previously, the `FlatRouteConfig` type concatenated string literal values of parent and child route paths directly. With the change from `flattenRouteConfig` to `formatRouteConfig`, the type was updated to remove search parameters from the child route path's string literal values that were present in the parent route's path.
- Changed exported functions and types: The `formatRouteConfig` function, which replaced the `flattenRouteConfig` function, is now exported. The `FlatRouteConfig` type is no longer exported; instead, the `FormattedRouteConfig` type, accurately representing the return value of the `formatRouteConfig` function, is exported. This change required updating import/export statements in `mod.ts`.
- Fixed `replaceParams` function: Previously, path and query parameters with the value `false` were replaced with empty strings. This was fixed to include `false` values as strings in the path, while `null` and `undefined` values are replaced with empty strings.
- Updated tests: Tests were cleaned up for better clarity and expanded to rigorously evaluate the package, accommodating more complex routing requirements.
