### PR TITLE
Revert function and file names, improve type strictness, and update tests

### DIFF
--- a/src/flattenConfig.ts
+++ b/src/flattenConfig.ts
@@ -1,10 +1,6 @@
 import { removeQueryArea } from "./generator.ts";
 import { Symbols } from "./symbols.ts";
-import type {
-  FlatRouteConfig,
-  FormatRouteConfig,
-  RouteConfig,
-} from "./types.ts";
+import type { FlatRouteConfig, FlatRoutes, RouteConfig } from "./types.ts";
 
 /**
  * Flattens the route configuration object.
@@ -38,11 +34,11 @@ import type {
  * @param result - The result object, used internally during recursion.
  * @returns The flattened route configuration.
  */
-export function formatRouteConfig<Config extends RouteConfig>(
+export function flattenRouteConfig<Config extends RouteConfig>(
   routeConfig: Config,
   parentPath = "",
   result: FlatRouteConfig = {},
-): FormatRouteConfig<Config> {
+): FlatRoutes<Config> {
   for (const parentRouteId in routeConfig) {
     const route = routeConfig[parentRouteId];
 
@@ -55,7 +51,7 @@ export function formatRouteConfig<Config extends RouteConfig>(
     if (route.children) {
       const parentPathToJoinChildren = removeQueryArea(fullPath);
 
-      const children = formatRouteConfig(
+      const children = flattenRouteConfig(
         route.children,
         parentPathToJoinChildren,
       );
@@ -68,5 +64,5 @@ export function formatRouteConfig<Config extends RouteConfig>(
       }
     }
   }
-  return result as FormatRouteConfig<Config>;
+  return result as FlatRoutes<Config>;
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,9 +1,9 @@
-import { formatRouteConfig } from "./formatConfig.ts";
+import { flattenRouteConfig } from "./flattenConfig.ts";
 import { createLinkGenerator } from "./generator.ts";
 import type {
   DefaultParameterType,
   ExtractRouteData,
-  FormatRouteConfig,
+  FlatRoutes,
   LinkGenerator,
   Parameter,
   ParameterAcceptValue,
@@ -15,8 +15,8 @@ export {
   createLinkGenerator,
   type DefaultParameterType,
   type ExtractRouteData,
-  type FormatRouteConfig,
-  formatRouteConfig,
+  type FlatRoutes,
+  flattenRouteConfig,
   type LinkGenerator,
   type Parameter,
   type ParameterAcceptValue,

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,6 +1,6 @@
 export enum Symbols {
   PathSeparater = "/",
-  Param = ":",
+  PathParam = ":",
   OptionalParam = "?",
   Search = "?",
   QuerySeparater = "&",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,8 +2,8 @@ import { assertEquals } from "$std/assert/mod.ts";
 import { describe, it } from "https://deno.land/std@0.224.0/testing/bdd.ts";
 import {
   createLinkGenerator,
-  type FormatRouteConfig,
-  formatRouteConfig,
+  type FlatRoutes,
+  flattenRouteConfig,
   type RouteConfig,
 } from "../src/mod.ts";
 
@@ -167,16 +167,16 @@ const flatResult = {
   "absoluteRoute/domain/static": "protocol://example.com/staticPage",
   "absoluteRoute/domain/withParam": "protocol://example.com/:param",
   "absoluteRoute/domain/withSearchParam": "protocol://example.com/?key",
-} as const satisfies FormatRouteConfig<typeof routeConfig>;
+} as const satisfies FlatRoutes<typeof routeConfig>;
 
 Deno.test("format function test", () => {
-  const flatConfig = formatRouteConfig(routeConfig);
+  const flatConfig = flattenRouteConfig(routeConfig);
 
   assertEquals(flatResult, flatConfig);
 });
 
 describe("generator function test", () => {
-  const flatConfig = formatRouteConfig(routeConfig);
+  const flatConfig = flattenRouteConfig(routeConfig);
 
   const link = createLinkGenerator(flatConfig);
 
@@ -274,16 +274,6 @@ describe("generator function test", () => {
           );
         });
       });
-
-      describe("param value is undefined", () => {
-        it("param value is not set", () => {
-          assertEquals("/dynamic", link("dynamicRoute/depth1"));
-        });
-
-        it("explicitly set to undefined", () => {
-          assertEquals("/dynamic", link("dynamicRoute/depth1", undefined));
-        });
-      });
     });
   });
 
@@ -291,14 +281,14 @@ describe("generator function test", () => {
     it("all search params have values set", () => {
       assertEquals(
         "/search?key=value",
-        link("withSearchParamsRoute/singleParam", null, { key: "value" }),
+        link("withSearchParamsRoute/singleParam", undefined, { key: "value" }),
       );
     });
 
     it("some search params have values set", () => {
       assertEquals(
         "/search?key1=value1&key2=value2",
-        link("withSearchParamsRoute/multiParams", null, {
+        link("withSearchParamsRoute/multiParams", undefined, {
           key1: "value1",
           key2: "value2",
         }),
@@ -306,14 +296,17 @@ describe("generator function test", () => {
     });
 
     it("all search params have the value undefined", () => {
-      assertEquals("/search", link("withSearchParamsRoute/multiParams", null));
+      assertEquals(
+        "/search",
+        link("withSearchParamsRoute/multiParams", undefined),
+      );
     });
 
     describe("search params with constraint filed", () => {
       it("string constraint", () => {
         assertEquals(
           "/constraint/searchParam?key=value",
-          link("constraintRoute/searchParam/stringConstraint", null, {
+          link("constraintRoute/searchParam/stringConstraint", undefined, {
             key: "value",
           }),
         );
@@ -322,7 +315,7 @@ describe("generator function test", () => {
       it("number constraint", () => {
         assertEquals(
           "/constraint/searchParam?key=1",
-          link("constraintRoute/searchParam/numberConstraint", null, {
+          link("constraintRoute/searchParam/numberConstraint", undefined, {
             key: 1,
           }),
         );
@@ -331,7 +324,7 @@ describe("generator function test", () => {
       it("boolean constraint", () => {
         assertEquals(
           "/constraint/searchParam?key=true",
-          link("constraintRoute/searchParam/booleanConstraint", null, {
+          link("constraintRoute/searchParam/booleanConstraint", undefined, {
             key: true,
           }),
         );
@@ -340,7 +333,7 @@ describe("generator function test", () => {
       it("optional constraint if value exists", () => {
         assertEquals(
           "/constraint/searchParam?key=value",
-          link("constraintRoute/searchParam/optionalConstraint", null, {
+          link("constraintRoute/searchParam/optionalConstraint", undefined, {
             key: "value",
           }),
         );
@@ -349,17 +342,21 @@ describe("generator function test", () => {
       it("optional constraint if value is not present", () => {
         assertEquals(
           "/constraint/searchParam",
-          link("constraintRoute/searchParam/optionalConstraint"),
+          link("constraintRoute/searchParam/optionalConstraint", undefined),
         );
       });
 
       it("all optional search parameters have the value undefined", () => {
         assertEquals(
           "/constraint/searchParam",
-          link("constraintRoute/searchParam/multipleOptionalConstraint", null, {
-            key1: undefined,
-            key2: undefined,
-          }),
+          link(
+            "constraintRoute/searchParam/multipleOptionalConstraint",
+            undefined,
+            {
+              key1: undefined,
+              key2: undefined,
+            },
+          ),
         );
       });
     });
@@ -383,7 +380,9 @@ describe("generator function test", () => {
     it("with search param", () => {
       assertEquals(
         "protocol://example.com?key=value",
-        link("absoluteRoute/domain/withSearchParam", null, { key: "value" }),
+        link("absoluteRoute/domain/withSearchParam", undefined, {
+          key: "value",
+        }),
       );
     });
   });


### PR DESCRIPTION
This pull request includes the following changes:

- Reverted function name from `formatRouteConfig` back to `flattenRouteConfig`.
- Reverted file name from `formatRouteConfig.ts` back to `flattenConfig.ts`.
- Renamed type from `FormattedRouteConfig` to `FlatRoutes` for better clarity.
- Improved type strictness:
  - Updated `createLinkGenerator` to dynamically generate link function parameter arguments, ensuring type errors if required parameters are not explicitly set.
  - Removed support for `null` in the second argument of the `link` function when query parameters exist, now only accepting `undefined`.
- Updated tests:
  - Adjusted tests to reflect changes in the `link` function's argument types, including removal of support for `null` values and ensuring strict parameter requirements.
  - Removed tests that previously allowed omission of the second argument or acceptance of `undefined` for paths requiring parameters.