### PR TITLE
 Improve type clarity, fix unnecessary type implementation, and strengthen documentation

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,9 +1,9 @@
 import type {
-  DefaultParameterType,
+  DefaultParamValue,
   FlatRouteConfig,
   LinkGenerator,
+  Param,
   ParamArgs,
-  Parameter,
 } from "./types.ts";
 import { Symbols } from "./symbols.ts";
 
@@ -66,9 +66,7 @@ export function createLinkGenerator<Config extends FlatRouteConfig>(
     path = replaceParams(path, pathParamEntry);
 
     if (searchParamEntry) {
-      const searchParams = createSearchParams(
-        searchParamEntry as unknown as Parameter,
-      );
+      const searchParams = createSearchParams(searchParamEntry as Param);
 
       // If all search parameters are undefined, no query parameters are added.
       searchParams ? (path += `?${searchParams}`) : "";
@@ -100,10 +98,7 @@ function removeConstrainedArea(path: string): string {
   return path.replace(constraintArea, "");
 }
 
-function replaceParams(
-  path: string,
-  params: Parameter | undefined | null,
-): string {
+function replaceParams(path: string, params: Param | undefined): string {
   const paramArea = new RegExp(
     `\\${Symbols.PathSeparater}${Symbols.PathParam}(?<paramName>[^\\/?]+)\\?${Symbols.OptionalParam}`,
     "g",
@@ -122,14 +117,14 @@ function replaceParams(
   });
 }
 
-function createSearchParams(search: Parameter): string {
+function createSearchParams(search: Param): string {
   return Object.entries(search)
     .filter(
       ([_, value]) => value !== "" && value !== undefined && value !== null,
     )
     .map(
       ([key, value]) =>
-        `${key}=${encodeURIComponent(value as DefaultParameterType)}`,
+        `${key}=${encodeURIComponent(value as DefaultParamValue)}`,
     )
     .join("&");
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,25 +1,25 @@
 import { flattenRouteConfig } from "./flattenConfig.ts";
 import { createLinkGenerator } from "./generator.ts";
 import type {
-  DefaultParameterType,
+  DefaultParamValue,
   ExtractRouteData,
   FlatRoutes,
   LinkGenerator,
-  Parameter,
-  ParameterAcceptValue,
+  Param,
+  ParamValue,
   Route,
   RouteConfig,
 } from "./types.ts";
 
 export {
   createLinkGenerator,
-  type DefaultParameterType,
+  type DefaultParamValue,
   type ExtractRouteData,
   type FlatRoutes,
   flattenRouteConfig,
   type LinkGenerator,
-  type Parameter,
-  type ParameterAcceptValue,
+  type Param,
+  type ParamValue,
   type Route,
   type RouteConfig,
 };


### PR DESCRIPTION
This pull request includes the following changes:

- Fixed unnecessary type implementation: The optional parameter type previously allowed `null` values in the parameter object, which was incorrect. Now it does not accept `null` values.
- Renamed types for better clarity: Changed `DefaultParameterType` to `DefaultParamValue`, `ParameterAcceptValue` to `ParamValue`, and `Params` to `PathParams`.
- Improved type inference performance: Reduced the number of type inferences in `PrunePaths` from three to two.
- Strengthened and clarified type definition documentation to improve readability and understanding.