### PR TITLE
Fix ExtractRouteData type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ bunx jsr add @kokomi/link-generator
 
 ### Search Parameters
 
-To define the search parameter field, write the path like this **Remember to
-prefix the query parameter with `/`!**
+> As of version 5, search parameters no longer need to be preceded by a `/`.
 
 Example:
 
@@ -117,7 +116,7 @@ Example:
    ```ts
    const routeConfig = {
      posts: {
-       path: "/posts/:postid/?page",
+       path: "/posts/:postid?page",
      },
    } as const satisfies RouteConfig;
    ```
@@ -184,7 +183,7 @@ Example:
        path: "/post/:postid<number>",
      },
      news: {
-       path: "/news/?is_archived<boolean>",
+       path: "/news?is_archived<boolean>",
      },
      category: {
        path: "/categories/:categoryid<(a|10|false)>",
@@ -224,6 +223,9 @@ Example:
 
 ### Optional Type
 
+> Starting with version 5, path parameters can no longer be optional, only
+> search parameters can be optional.
+
 Parameter value types are `string | number | boolean` by default.
 
 If you want some parameter value to be optional (receive undefined), you can put
@@ -234,7 +236,7 @@ Example:
 ```ts
 const routeConfig = {
   product: {
-    path: "/products/:productid?",
+    path: "/products?size?&category",
   },
 } as const satisfies RouteConfig;
 
@@ -290,7 +292,7 @@ const routeConfig = {
     path: "users/:userid",
   },
   news: {
-    path: "news/?is_archived<boolean>",
+    path: "news?is_archived<boolean>",
   },
 } as const satisfies RouteConfig;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
-import type { Symbols } from './symbols.ts';
+import type { Symbols } from "./symbols.ts";
 
 /**
  * Represents a single route in the application.
  * Each route has a path and optionally nested child routes.
  */
 type Route = {
-	path: string;
-	children?: RouteConfig;
+  path: string;
+  children?: RouteConfig;
 };
 
 /**
@@ -14,7 +14,7 @@ type Route = {
  * This type maps route IDs to their respective route definitions.
  */
 type RouteConfig = {
-	[routeId: string]: Route;
+  [routeId: string]: Route;
 };
 
 /**
@@ -26,38 +26,35 @@ type RouteConfig = {
  * @returns The generated link.
  */
 type LinkGenerator<Config extends FlatRouteConfig> = <
-	RouteId extends keyof Config
+  RouteId extends keyof Config,
 >(
-	routeId: RouteId,
-	...params: ParamArgs<Config, RouteId>
+  routeId: RouteId,
+  ...params: ParamArgs<Config, RouteId>
 ) => string;
 
 type FlatRouteConfig = Record<string, string>;
 
 type Split<
-	Source extends string,
-	Separator extends string
-> = string extends Source
-	? string[]
-	: Source extends ''
-	? []
-	: Source extends `${infer Before}${Separator}${infer After}`
-	? [Before, ...Split<After, Separator>]
-	: [Source];
+  Source extends string,
+  Separator extends string,
+> = string extends Source ? string[]
+  : Source extends "" ? []
+  : Source extends `${infer Before}${Separator}${infer After}`
+    ? [Before, ...Split<After, Separator>]
+  : [Source];
 
 type ParseSegment<Path extends string> = Split<Path, Symbols.PathSeparater>;
 
 type ParseSearchParams<SearchParams extends string> = Split<
-	SearchParams,
-	Symbols.SearchParamSeparator
+  SearchParams,
+  Symbols.SearchParamSeparator
 >;
 
 // deno-lint-ignore no-explicit-any
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-	k: infer I
-) => void
-	? I
-	: never;
+  k: infer I,
+) => void ? I
+  : never;
 
 /**
  * The default value type for path or search parameters without constraints.
@@ -92,71 +89,66 @@ type DefaultParamValue = string | number | boolean;
  */
 type Param = Record<string, DefaultParamValue>;
 
-type StringToBoolean<UnionSegment extends string> = UnionSegment extends 'true'
-	? true
-	: UnionSegment extends 'false'
-	? false
-	: UnionSegment;
+type StringToBoolean<UnionSegment extends string> = UnionSegment extends "true"
+  ? true
+  : UnionSegment extends "false" ? false
+  : UnionSegment;
 
-type StringToNumber<UnionSegment extends string> =
-	UnionSegment extends `${infer NumericString extends number}`
-		? NumericString
-		: UnionSegment;
+type StringToNumber<UnionSegment extends string> = UnionSegment extends
+  `${infer NumericString extends number}` ? NumericString
+  : UnionSegment;
 
 type ParseUnion<UnionString extends string> = StringToBoolean<
-	StringToNumber<Split<UnionString, Symbols.UnionSeparater>[number]>
+  StringToNumber<Split<UnionString, Symbols.UnionSeparater>[number]>
 >;
 
-type InferParamType<Constraint extends string> = Constraint extends 'string'
-	? string
-	: Constraint extends 'number'
-	? number
-	: Constraint extends 'boolean'
-	? boolean
-	: Constraint extends `${Symbols.UnionOpen}${infer Union}${Symbols.UnionClose}`
-	? ParseUnion<Union>
-	: never;
+type InferParamType<Constraint extends string> = Constraint extends "string"
+  ? string
+  : Constraint extends "number" ? number
+  : Constraint extends "boolean" ? boolean
+  : Constraint extends `${Symbols.UnionOpen}${infer Union}${Symbols.UnionClose}`
+    ? ParseUnion<Union>
+  : never;
 
-type CreatePathParams<Segment extends string> =
-	Segment extends `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
-		? Record<ParamName, InferParamType<Constraint>>
-		: Record<Segment, DefaultParamValue>;
+type CreatePathParams<Segment extends string> = Segment extends
+  `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
+  ? Record<ParamName, InferParamType<Constraint>>
+  : Record<Segment, DefaultParamValue>;
 
-type CreateSearchParams<Segment extends string> =
-	Segment extends `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}${Symbols.OptionalParam}`
-		? Partial<Record<ParamName, InferParamType<Constraint>>>
-		: Segment extends `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
-		? Record<ParamName, InferParamType<Constraint>>
-		: Segment extends `${infer ParamName}${Symbols.OptionalParam}`
-		? Partial<Record<ParamName, DefaultParamValue>>
-		: Record<Segment, DefaultParamValue>;
+type CreateSearchParams<Segment extends string> = Segment extends
+  `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}${Symbols.OptionalParam}`
+  ? Partial<Record<ParamName, InferParamType<Constraint>>>
+  : Segment extends
+    `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
+    ? Record<ParamName, InferParamType<Constraint>>
+  : Segment extends `${infer ParamName}${Symbols.OptionalParam}`
+    ? Partial<Record<ParamName, DefaultParamValue>>
+  : Record<Segment, DefaultParamValue>;
 
-type FindPathParams<Segment> =
-	Segment extends `${Symbols.PathParam}${infer ParamField}`
-		? ParamField extends `${infer ParamName}${Symbols.SearchParam}${infer SearchField}`
-			? ParamName
-			: ParamField
-		: never;
+type FindPathParams<Segment> = Segment extends
+  `${Symbols.PathParam}${infer ParamField}`
+  ? ParamField extends
+    `${infer ParamName}${Symbols.SearchParam}${infer SearchField}` ? ParamName
+  : ParamField
+  : never;
 
-type FindSearchParams<Path extends string> =
-	Path extends `${infer Head}${Symbols.SearchParam}${infer SearchParams}`
-		? SearchParams
-		: never;
+type FindSearchParams<Path extends string> = Path extends
+  `${infer Head}${Symbols.SearchParam}${infer SearchParams}` ? SearchParams
+  : never;
 
 type PathParams<Path extends string> = UnionToIntersection<
-	CreatePathParams<FindPathParams<ParseSegment<Path>[number]>>
+  CreatePathParams<FindPathParams<ParseSegment<Path>[number]>>
 >;
 
 type IsType<CheckType, TargetType> = CheckType extends TargetType
-	? TargetType extends CheckType
-		? true
-		: false
-	: false;
+  ? TargetType extends CheckType ? true
+  : false
+  : false;
 
 type IsUnknownType<T> = IsType<unknown, T>;
 
 type SearchParams<Path extends string> = UnionToIntersection<
-	CreateSearchParams<ParseSearchParams<FindSearchParams<Path>>[number]>
+  CreateSearchParams<ParseSearchParams<FindSearchParams<Path>>[number]>
 >;
 
 /**
@@ -187,30 +179,28 @@ type SearchParams<Path extends string> = UnionToIntersection<
  * ```
  */
 type ExtractRouteData<FlattenedRoutes extends FlatRouteConfig> = {
-	[RouteId in keyof FlattenedRoutes]: {
-		path: FlattenedRoutes[RouteId];
-		params: IsUnknownType<PathParams<FlattenedRoutes[RouteId]>> extends true
-			? never
-			: PathParams<FlattenedRoutes[RouteId]>;
-		search: IsUnknownType<SearchParams<FlattenedRoutes[RouteId]>> extends true
-			? never
-			: SearchParams<FlattenedRoutes[RouteId]>;
-	};
+  [RouteId in keyof FlattenedRoutes]: {
+    path: FlattenedRoutes[RouteId];
+    params: IsUnknownType<PathParams<FlattenedRoutes[RouteId]>> extends true
+      ? never
+      : PathParams<FlattenedRoutes[RouteId]>;
+    search: IsUnknownType<SearchParams<FlattenedRoutes[RouteId]>> extends true
+      ? never
+      : SearchParams<FlattenedRoutes[RouteId]>;
+  };
 };
 
-type NestedKeys<Config> = Config extends RouteConfig
-	? {
-			[ParentKey in keyof Config]: ParentKey extends string
-				? Config[ParentKey] extends { children: RouteConfig }
-					?
-							| `${ParentKey}`
-							| `${ParentKey}${Symbols.PathSeparater}${NestedKeys<
-									Config[ParentKey]['children']
-							  >}`
-					: ParentKey
-				: never;
-	  }[keyof Config]
-	: never;
+type NestedKeys<Config> = Config extends RouteConfig ? {
+    [ParentKey in keyof Config]: ParentKey extends string
+      ? Config[ParentKey] extends { children: RouteConfig } ?
+          | `${ParentKey}`
+          | `${ParentKey}${Symbols.PathSeparater}${NestedKeys<
+            Config[ParentKey]["children"]
+          >}`
+      : ParentKey
+      : never;
+  }[keyof Config]
+  : never;
 
 /**
  * Flattens the route configuration object into a simpler structure.
@@ -235,18 +225,18 @@ type NestedKeys<Config> = Config extends RouteConfig
  * ```
  */
 type FlattenRouteConfig<
-	Config,
-	ParentPath extends string = ''
-> = Config extends RouteConfig
-	? {
-			[RouteId in NestedKeys<Config>]: RouteId extends `${infer ParentRouteId}${Symbols.PathSeparater}${infer ChildrenRouteId}`
-				? FlattenRouteConfig<
-						Config[ParentRouteId]['children'],
-						`${ParentPath}${Config[ParentRouteId]['path']}`
-				  >[ChildrenRouteId]
-				: `${ParentPath}${Config[RouteId]['path']}`;
-	  }
-	: never;
+  Config,
+  ParentPath extends string = "",
+> = Config extends RouteConfig ? {
+    [RouteId in NestedKeys<Config>]: RouteId extends
+      `${infer ParentRouteId}${Symbols.PathSeparater}${infer ChildrenRouteId}`
+      ? FlattenRouteConfig<
+        Config[ParentRouteId]["children"],
+        `${ParentPath}${Config[ParentRouteId]["path"]}`
+      >[ChildrenRouteId]
+      : `${ParentPath}${Config[RouteId]["path"]}`;
+  }
+  : never;
 
 /**
  * Removes parent search parameters from a given route path.
@@ -261,10 +251,10 @@ type FlattenRouteConfig<
  * // => '/parentpath/childpath/?ckey1&ckey2' }
  * ```
  */
-type RemoveParentSearchParams<Path extends string> =
-	Path extends `${infer Head}${Symbols.SearchParam}${infer Middle}${Symbols.PathSeparater}${infer Tail}`
-		? RemoveParentSearchParams<`${Head}${Symbols.PathSeparater}${Tail}`>
-		: Path;
+type RemoveParentSearchParams<Path extends string> = Path extends
+  `${infer Head}${Symbols.SearchParam}${infer Middle}${Symbols.PathSeparater}${infer Tail}`
+  ? RemoveParentSearchParams<`${Head}${Symbols.PathSeparater}${Tail}`>
+  : Path;
 
 /**
  * Removes parent search parameters from the flattened route configuration.
@@ -301,13 +291,13 @@ type RemoveParentSearchParams<Path extends string> =
  * }
  * ```
  */
-type PrunePaths<Config> = Config extends FlatRouteConfig
-	? {
-			[RouteId in keyof Config]: Config[RouteId] extends `${infer Protocol}:/${infer Rest}` // Is absolute path?
-				? `${Protocol}:/${RemoveParentSearchParams<Rest>}`
-				: RemoveParentSearchParams<Config[RouteId]>;
-	  }
-	: never;
+type PrunePaths<Config> = Config extends FlatRouteConfig ? {
+    [RouteId in keyof Config]: Config[RouteId] extends
+      `${infer Protocol}:/${infer Rest}` // Is absolute path?
+      ? `${Protocol}:/${RemoveParentSearchParams<Rest>}`
+      : RemoveParentSearchParams<Config[RouteId]>;
+  }
+  : never;
 
 /**
  * Flattens the route configuration object and removes parent search parameters.
@@ -353,25 +343,25 @@ type EmptyObject = Record<string, never>;
  * Extracts path and search parameters for a given route.
  */
 type ParamArgs<
-	Config extends FlatRouteConfig,
-	RouteId extends keyof Config
-> = ExtractRouteData<Config>[RouteId]['params'] extends EmptyObject
-	? [undefined?, ExtractRouteData<Config>[RouteId]['search']?]
-	: IsUnknownType<ExtractRouteData<Config>[RouteId]['params']> extends true
-	? [undefined?, ExtractRouteData<Config>[RouteId]['search']?]
-	: [
-			ExtractRouteData<Config>[RouteId]['params'],
-			ExtractRouteData<Config>[RouteId]['search']?
-	  ];
+  Config extends FlatRouteConfig,
+  RouteId extends keyof Config,
+> = ExtractRouteData<Config>[RouteId]["params"] extends EmptyObject
+  ? [undefined?, ExtractRouteData<Config>[RouteId]["search"]?]
+  : IsUnknownType<ExtractRouteData<Config>[RouteId]["params"]> extends true
+    ? [undefined?, ExtractRouteData<Config>[RouteId]["search"]?]
+  : [
+    ExtractRouteData<Config>[RouteId]["params"],
+    ExtractRouteData<Config>[RouteId]["search"]?,
+  ];
 
 export type {
-	DefaultParamValue,
-	ExtractRouteData,
-	FlatRouteConfig,
-	FlatRoutes,
-	LinkGenerator,
-	Param,
-	ParamArgs,
-	Route,
-	RouteConfig,
+  DefaultParamValue,
+  ExtractRouteData,
+  FlatRouteConfig,
+  FlatRoutes,
+  LinkGenerator,
+  Param,
+  ParamArgs,
+  Route,
+  RouteConfig,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,9 +140,12 @@ type PathParams<Path extends string> = UnionToIntersection<
   CreatePathParams<FindPathParams<ParseSegment<Path>[number]>>
 >;
 
-type IsUnknownType<T> = unknown extends T ? T extends unknown ? true
+type IsType<CheckType, TargetType> = CheckType extends TargetType
+  ? TargetType extends CheckType ? true
   : false
   : false;
+
+type IsUnknownType<T> = IsType<unknown, T>;
 
 type SearchParams<Path extends string> = UnionToIntersection<
   CreateSearchParams<ParseSearchParams<FindSearchParams<Path>>[number]>
@@ -178,8 +181,12 @@ type SearchParams<Path extends string> = UnionToIntersection<
 type ExtractRouteData<FlattenedRoutes extends FlatRouteConfig> = {
   [RouteId in keyof FlattenedRoutes]: {
     path: FlattenedRoutes[RouteId];
-    params: PathParams<FlattenedRoutes[RouteId]>;
-    search: SearchParams<FlattenedRoutes[RouteId]>;
+    params: IsUnknownType<PathParams<FlattenedRoutes[RouteId]>> extends true
+      ? never
+      : PathParams<FlattenedRoutes[RouteId]>;
+    search: IsUnknownType<SearchParams<FlattenedRoutes[RouteId]>> extends true
+      ? never
+      : SearchParams<FlattenedRoutes[RouteId]>;
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
-import type { Symbols } from "./symbols.ts";
+import type { Symbols } from './symbols.ts';
 
 /**
  * Represents a single route in the application.
  * Each route has a path and optionally nested child routes.
  */
 type Route = {
-  path: string;
-  children?: RouteConfig;
+	path: string;
+	children?: RouteConfig;
 };
 
 /**
@@ -14,7 +14,7 @@ type Route = {
  * This type maps route IDs to their respective route definitions.
  */
 type RouteConfig = {
-  [routeId: string]: Route;
+	[routeId: string]: Route;
 };
 
 /**
@@ -26,35 +26,38 @@ type RouteConfig = {
  * @returns The generated link.
  */
 type LinkGenerator<Config extends FlatRouteConfig> = <
-  RouteId extends keyof Config,
+	RouteId extends keyof Config
 >(
-  routeId: RouteId,
-  ...params: ParamArgs<Config, RouteId>
+	routeId: RouteId,
+	...params: ParamArgs<Config, RouteId>
 ) => string;
 
 type FlatRouteConfig = Record<string, string>;
 
 type Split<
-  Source extends string,
-  Separator extends string,
-> = string extends Source ? string[]
-  : Source extends "" ? []
-  : Source extends `${infer Before}${Separator}${infer After}`
-    ? [Before, ...Split<After, Separator>]
-  : [Source];
+	Source extends string,
+	Separator extends string
+> = string extends Source
+	? string[]
+	: Source extends ''
+	? []
+	: Source extends `${infer Before}${Separator}${infer After}`
+	? [Before, ...Split<After, Separator>]
+	: [Source];
 
 type ParseSegment<Path extends string> = Split<Path, Symbols.PathSeparater>;
 
 type ParseSearchParams<SearchParams extends string> = Split<
-  SearchParams,
-  Symbols.SearchParamSeparator
+	SearchParams,
+	Symbols.SearchParamSeparator
 >;
 
 // deno-lint-ignore no-explicit-any
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I,
-) => void ? I
-  : never;
+	k: infer I
+) => void
+	? I
+	: never;
 
 /**
  * The default value type for path or search parameters without constraints.
@@ -89,63 +92,71 @@ type DefaultParamValue = string | number | boolean;
  */
 type Param = Record<string, DefaultParamValue>;
 
-type StringToBoolean<UnionSegment extends string> = UnionSegment extends "true"
-  ? true
-  : UnionSegment extends "false" ? false
-  : UnionSegment;
+type StringToBoolean<UnionSegment extends string> = UnionSegment extends 'true'
+	? true
+	: UnionSegment extends 'false'
+	? false
+	: UnionSegment;
 
-type StringToNumber<UnionSegment extends string> = UnionSegment extends
-  `${infer NumericString extends number}` ? NumericString
-  : UnionSegment;
+type StringToNumber<UnionSegment extends string> =
+	UnionSegment extends `${infer NumericString extends number}`
+		? NumericString
+		: UnionSegment;
 
 type ParseUnion<UnionString extends string> = StringToBoolean<
-  StringToNumber<Split<UnionString, Symbols.UnionSeparater>[number]>
+	StringToNumber<Split<UnionString, Symbols.UnionSeparater>[number]>
 >;
 
-type InferParamType<Constraint extends string> = Constraint extends "string"
-  ? string
-  : Constraint extends "number" ? number
-  : Constraint extends "boolean" ? boolean
-  : Constraint extends `${Symbols.UnionOpen}${infer Union}${Symbols.UnionClose}`
-    ? ParseUnion<Union>
-  : never;
+type InferParamType<Constraint extends string> = Constraint extends 'string'
+	? string
+	: Constraint extends 'number'
+	? number
+	: Constraint extends 'boolean'
+	? boolean
+	: Constraint extends `${Symbols.UnionOpen}${infer Union}${Symbols.UnionClose}`
+	? ParseUnion<Union>
+	: never;
 
-type CreatePathParams<Segment extends string> = Segment extends
-  `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
-  ? Record<ParamName, InferParamType<Constraint>>
-  : Record<Segment, DefaultParamValue>;
+type CreatePathParams<Segment extends string> =
+	Segment extends `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
+		? Record<ParamName, InferParamType<Constraint>>
+		: Record<Segment, DefaultParamValue>;
 
-type CreateSearchParams<Segment extends string> = Segment extends
-  `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}${Symbols.OptionalParam}`
-  ? Partial<Record<ParamName, InferParamType<Constraint>>>
-  : Segment extends
-    `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
-    ? Record<ParamName, InferParamType<Constraint>>
-  : Segment extends `${infer ParamName}${Symbols.OptionalParam}`
-    ? Partial<Record<ParamName, DefaultParamValue>>
-  : Record<Segment, DefaultParamValue>;
+type CreateSearchParams<Segment extends string> =
+	Segment extends `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}${Symbols.OptionalParam}`
+		? Partial<Record<ParamName, InferParamType<Constraint>>>
+		: Segment extends `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
+		? Record<ParamName, InferParamType<Constraint>>
+		: Segment extends `${infer ParamName}${Symbols.OptionalParam}`
+		? Partial<Record<ParamName, DefaultParamValue>>
+		: Record<Segment, DefaultParamValue>;
 
-type FindPathParams<Segment> = Segment extends
-  `${Symbols.PathParam}${infer ParamField}`
-  ? ParamField extends
-    `${infer ParamName}${Symbols.SearchParam}${infer SearchField}` ? ParamName
-  : ParamField
-  : never;
+type FindPathParams<Segment> =
+	Segment extends `${Symbols.PathParam}${infer ParamField}`
+		? ParamField extends `${infer ParamName}${Symbols.SearchParam}${infer SearchField}`
+			? ParamName
+			: ParamField
+		: never;
 
-type FindSearchParams<Path extends string> = Path extends
-  `${infer Head}${Symbols.SearchParam}${infer SearchParams}` ? SearchParams
-  : never;
+type FindSearchParams<Path extends string> =
+	Path extends `${infer Head}${Symbols.SearchParam}${infer SearchParams}`
+		? SearchParams
+		: never;
 
 type PathParams<Path extends string> = UnionToIntersection<
-  CreatePathParams<FindPathParams<ParseSegment<Path>[number]>>
+	CreatePathParams<FindPathParams<ParseSegment<Path>[number]>>
 >;
 
-type IsUnknownType<T> = unknown extends T ? T extends unknown ? true
-  : false
-  : false;
+type IsType<CheckType, TargetType> = CheckType extends TargetType
+	? TargetType extends CheckType
+		? true
+		: false
+	: false;
+
+type IsUnknownType<T> = IsType<unknown, T>;
 
 type SearchParams<Path extends string> = UnionToIntersection<
-  CreateSearchParams<ParseSearchParams<FindSearchParams<Path>>[number]>
+	CreateSearchParams<ParseSearchParams<FindSearchParams<Path>>[number]>
 >;
 
 /**
@@ -176,24 +187,30 @@ type SearchParams<Path extends string> = UnionToIntersection<
  * ```
  */
 type ExtractRouteData<FlattenedRoutes extends FlatRouteConfig> = {
-  [RouteId in keyof FlattenedRoutes]: {
-    path: FlattenedRoutes[RouteId];
-    params: PathParams<FlattenedRoutes[RouteId]>;
-    search: SearchParams<FlattenedRoutes[RouteId]>;
-  };
+	[RouteId in keyof FlattenedRoutes]: {
+		path: FlattenedRoutes[RouteId];
+		params: IsUnknownType<PathParams<FlattenedRoutes[RouteId]>> extends true
+			? never
+			: PathParams<FlattenedRoutes[RouteId]>;
+		search: IsUnknownType<SearchParams<FlattenedRoutes[RouteId]>> extends true
+			? never
+			: SearchParams<FlattenedRoutes[RouteId]>;
+	};
 };
 
-type NestedKeys<Config> = Config extends RouteConfig ? {
-    [ParentKey in keyof Config]: ParentKey extends string
-      ? Config[ParentKey] extends { children: RouteConfig } ?
-          | `${ParentKey}`
-          | `${ParentKey}${Symbols.PathSeparater}${NestedKeys<
-            Config[ParentKey]["children"]
-          >}`
-      : ParentKey
-      : never;
-  }[keyof Config]
-  : never;
+type NestedKeys<Config> = Config extends RouteConfig
+	? {
+			[ParentKey in keyof Config]: ParentKey extends string
+				? Config[ParentKey] extends { children: RouteConfig }
+					?
+							| `${ParentKey}`
+							| `${ParentKey}${Symbols.PathSeparater}${NestedKeys<
+									Config[ParentKey]['children']
+							  >}`
+					: ParentKey
+				: never;
+	  }[keyof Config]
+	: never;
 
 /**
  * Flattens the route configuration object into a simpler structure.
@@ -218,18 +235,18 @@ type NestedKeys<Config> = Config extends RouteConfig ? {
  * ```
  */
 type FlattenRouteConfig<
-  Config,
-  ParentPath extends string = "",
-> = Config extends RouteConfig ? {
-    [RouteId in NestedKeys<Config>]: RouteId extends
-      `${infer ParentRouteId}${Symbols.PathSeparater}${infer ChildrenRouteId}`
-      ? FlattenRouteConfig<
-        Config[ParentRouteId]["children"],
-        `${ParentPath}${Config[ParentRouteId]["path"]}`
-      >[ChildrenRouteId]
-      : `${ParentPath}${Config[RouteId]["path"]}`;
-  }
-  : never;
+	Config,
+	ParentPath extends string = ''
+> = Config extends RouteConfig
+	? {
+			[RouteId in NestedKeys<Config>]: RouteId extends `${infer ParentRouteId}${Symbols.PathSeparater}${infer ChildrenRouteId}`
+				? FlattenRouteConfig<
+						Config[ParentRouteId]['children'],
+						`${ParentPath}${Config[ParentRouteId]['path']}`
+				  >[ChildrenRouteId]
+				: `${ParentPath}${Config[RouteId]['path']}`;
+	  }
+	: never;
 
 /**
  * Removes parent search parameters from a given route path.
@@ -244,10 +261,10 @@ type FlattenRouteConfig<
  * // => '/parentpath/childpath/?ckey1&ckey2' }
  * ```
  */
-type RemoveParentSearchParams<Path extends string> = Path extends
-  `${infer Head}${Symbols.SearchParam}${infer Middle}${Symbols.PathSeparater}${infer Tail}`
-  ? RemoveParentSearchParams<`${Head}${Symbols.PathSeparater}${Tail}`>
-  : Path;
+type RemoveParentSearchParams<Path extends string> =
+	Path extends `${infer Head}${Symbols.SearchParam}${infer Middle}${Symbols.PathSeparater}${infer Tail}`
+		? RemoveParentSearchParams<`${Head}${Symbols.PathSeparater}${Tail}`>
+		: Path;
 
 /**
  * Removes parent search parameters from the flattened route configuration.
@@ -284,13 +301,13 @@ type RemoveParentSearchParams<Path extends string> = Path extends
  * }
  * ```
  */
-type PrunePaths<Config> = Config extends FlatRouteConfig ? {
-    [RouteId in keyof Config]: Config[RouteId] extends
-      `${infer Protocol}:/${infer Rest}` // Is absolute path?
-      ? `${Protocol}:/${RemoveParentSearchParams<Rest>}`
-      : RemoveParentSearchParams<Config[RouteId]>;
-  }
-  : never;
+type PrunePaths<Config> = Config extends FlatRouteConfig
+	? {
+			[RouteId in keyof Config]: Config[RouteId] extends `${infer Protocol}:/${infer Rest}` // Is absolute path?
+				? `${Protocol}:/${RemoveParentSearchParams<Rest>}`
+				: RemoveParentSearchParams<Config[RouteId]>;
+	  }
+	: never;
 
 /**
  * Flattens the route configuration object and removes parent search parameters.
@@ -336,25 +353,25 @@ type EmptyObject = Record<string, never>;
  * Extracts path and search parameters for a given route.
  */
 type ParamArgs<
-  Config extends FlatRouteConfig,
-  RouteId extends keyof Config,
-> = ExtractRouteData<Config>[RouteId]["params"] extends EmptyObject
-  ? [undefined?, ExtractRouteData<Config>[RouteId]["search"]?]
-  : IsUnknownType<ExtractRouteData<Config>[RouteId]["params"]> extends true
-    ? [undefined?, ExtractRouteData<Config>[RouteId]["search"]?]
-  : [
-    ExtractRouteData<Config>[RouteId]["params"],
-    ExtractRouteData<Config>[RouteId]["search"]?,
-  ];
+	Config extends FlatRouteConfig,
+	RouteId extends keyof Config
+> = ExtractRouteData<Config>[RouteId]['params'] extends EmptyObject
+	? [undefined?, ExtractRouteData<Config>[RouteId]['search']?]
+	: IsUnknownType<ExtractRouteData<Config>[RouteId]['params']> extends true
+	? [undefined?, ExtractRouteData<Config>[RouteId]['search']?]
+	: [
+			ExtractRouteData<Config>[RouteId]['params'],
+			ExtractRouteData<Config>[RouteId]['search']?
+	  ];
 
 export type {
-  DefaultParamValue,
-  ExtractRouteData,
-  FlatRouteConfig,
-  FlatRoutes,
-  LinkGenerator,
-  Param,
-  ParamArgs,
-  Route,
-  RouteConfig,
+	DefaultParamValue,
+	ExtractRouteData,
+	FlatRouteConfig,
+	FlatRoutes,
+	LinkGenerator,
+	Param,
+	ParamArgs,
+	Route,
+	RouteConfig,
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,6 +6,7 @@ import {
   flattenRouteConfig,
   type RouteConfig,
 } from "../src/mod.ts";
+import { ExtractRouteData } from "../src/types.ts";
 
 const routeConfig = {
   staticRoute: {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,351 +1,350 @@
-import { assertEquals } from "$std/assert/mod.ts";
-import { describe, it } from "https://deno.land/std@0.224.0/testing/bdd.ts";
+import { assertEquals } from '$std/assert/mod.ts';
+import { describe, it } from 'https://deno.land/std@0.224.0/testing/bdd.ts';
 import {
-  createLinkGenerator,
-  type FlatRoutes,
-  flattenRouteConfig,
-  type RouteConfig,
-} from "../src/mod.ts";
-import { ExtractRouteData } from "../src/types.ts";
+	createLinkGenerator,
+	type FlatRoutes,
+	flattenRouteConfig,
+	type RouteConfig,
+} from '../src/mod.ts';
 
 const routeConfig = {
-  staticRoute: {
-    path: "/",
-  },
-  dynamicRoute: {
-    path: "/dynamic",
-    children: {
-      depth1: {
-        path: "/:param1",
-        children: {
-          depth2: {
-            path: "/depth2/:param2",
-          },
-        },
-      },
-    },
-  },
-  constraintRoute: {
-    path: "/constraint",
-    children: {
-      param: {
-        path: "/param",
-        children: {
-          stringConstraint: {
-            path: "/:param<string>",
-          },
-          numberConstraint: {
-            path: "/:param<number>",
-          },
-          booleanConstraint: {
-            path: "/:param<boolean>",
-          },
-          unionConstraint: {
-            path: "/:param<(a|1|false)>",
-          },
-        },
-      },
-      searchParam: {
-        path: "/searchParam",
-        children: {
-          stringConstraint: {
-            path: "?key<string>",
-          },
-          numberConstraint: {
-            path: "?key<number>",
-          },
-          booleanConstraint: {
-            path: "?key<boolean>",
-          },
-          unionConstraint: {
-            path: "?key<(a|1|false)>",
-          },
-        },
-      },
-    },
-  },
-  withSearchParamsRoute: {
-    path: "/search",
-    children: {
-      singleParam: {
-        path: "?key",
-      },
-      multiParams: {
-        path: "?key1&key2",
-      },
-      optionalParam: {
-        path: "?key1?&key2",
-      },
-    },
-  },
-  mixRoute: {
-    path: "/mix",
-    children: {
-      signle: {
-        path: "/:param1?searchParam1",
-      },
-      multipleParams: {
-        path: "/:param2/:param3?searchParam1",
-      },
-      multipleSearchParams: {
-        path: "/:param3?searchParam1&searchParam2",
-      },
-      nested: {
-        path: "/nested?searchParam1",
-        children: {
-          depth1: {
-            path: "/:param1?searchParam2",
-          },
-        },
-      },
-    },
-  },
-  absoluteRoute: {
-    path: "protocol://",
-    children: {
-      domain: {
-        path: "example.com",
-        children: {
-          static: {
-            path: "/staticPage",
-          },
-          withParam: {
-            path: "/:param?key",
-          },
-        },
-      },
-    },
-  },
+	staticRoute: {
+		path: '/',
+	},
+	dynamicRoute: {
+		path: '/dynamic',
+		children: {
+			depth1: {
+				path: '/:param1',
+				children: {
+					depth2: {
+						path: '/depth2/:param2',
+					},
+				},
+			},
+		},
+	},
+	constraintRoute: {
+		path: '/constraint',
+		children: {
+			param: {
+				path: '/param',
+				children: {
+					stringConstraint: {
+						path: '/:param<string>',
+					},
+					numberConstraint: {
+						path: '/:param<number>',
+					},
+					booleanConstraint: {
+						path: '/:param<boolean>',
+					},
+					unionConstraint: {
+						path: '/:param<(a|1|false)>',
+					},
+				},
+			},
+			searchParam: {
+				path: '/searchParam',
+				children: {
+					stringConstraint: {
+						path: '?key<string>',
+					},
+					numberConstraint: {
+						path: '?key<number>',
+					},
+					booleanConstraint: {
+						path: '?key<boolean>',
+					},
+					unionConstraint: {
+						path: '?key<(a|1|false)>',
+					},
+				},
+			},
+		},
+	},
+	withSearchParamsRoute: {
+		path: '/search',
+		children: {
+			singleParam: {
+				path: '?key',
+			},
+			multiParams: {
+				path: '?key1&key2',
+			},
+			optionalParam: {
+				path: '?key1?&key2',
+			},
+		},
+	},
+	mixRoute: {
+		path: '/mix',
+		children: {
+			signle: {
+				path: '/:param1?searchParam1',
+			},
+			multipleParams: {
+				path: '/:param2/:param3?searchParam1',
+			},
+			multipleSearchParams: {
+				path: '/:param3?searchParam1&searchParam2',
+			},
+			nested: {
+				path: '/nested?searchParam1',
+				children: {
+					depth1: {
+						path: '/:param1?searchParam2',
+					},
+				},
+			},
+		},
+	},
+	absoluteRoute: {
+		path: 'protocol://',
+		children: {
+			domain: {
+				path: 'example.com',
+				children: {
+					static: {
+						path: '/staticPage',
+					},
+					withParam: {
+						path: '/:param?key',
+					},
+				},
+			},
+		},
+	},
 } as const satisfies RouteConfig;
 
 const flatResult = {
-  staticRoute: "/",
-  dynamicRoute: "/dynamic",
-  "dynamicRoute/depth1": "/dynamic/:param1",
-  "dynamicRoute/depth1/depth2": "/dynamic/:param1/depth2/:param2",
-  constraintRoute: "/constraint",
-  "constraintRoute/param": "/constraint/param",
-  "constraintRoute/param/stringConstraint": "/constraint/param/:param<string>",
-  "constraintRoute/param/numberConstraint": "/constraint/param/:param<number>",
-  "constraintRoute/param/booleanConstraint":
-    "/constraint/param/:param<boolean>",
-  "constraintRoute/param/unionConstraint":
-    "/constraint/param/:param<(a|1|false)>",
-  "constraintRoute/searchParam": "/constraint/searchParam",
-  "constraintRoute/searchParam/stringConstraint":
-    "/constraint/searchParam?key<string>",
-  "constraintRoute/searchParam/numberConstraint":
-    "/constraint/searchParam?key<number>",
-  "constraintRoute/searchParam/booleanConstraint":
-    "/constraint/searchParam?key<boolean>",
-  "constraintRoute/searchParam/unionConstraint":
-    "/constraint/searchParam?key<(a|1|false)>",
-  withSearchParamsRoute: "/search",
-  "withSearchParamsRoute/singleParam": "/search?key",
-  "withSearchParamsRoute/multiParams": "/search?key1&key2",
-  "withSearchParamsRoute/optionalParam": "/search?key1?&key2",
-  mixRoute: "/mix",
-  "mixRoute/signle": "/mix/:param1?searchParam1",
-  "mixRoute/multipleParams": "/mix/:param2/:param3?searchParam1",
-  "mixRoute/multipleSearchParams": "/mix/:param3?searchParam1&searchParam2",
-  "mixRoute/nested": "/mix/nested?searchParam1",
-  "mixRoute/nested/depth1": "/mix/nested/:param1?searchParam2",
-  absoluteRoute: "protocol://",
-  "absoluteRoute/domain": "protocol://example.com",
-  "absoluteRoute/domain/static": "protocol://example.com/staticPage",
-  "absoluteRoute/domain/withParam": "protocol://example.com/:param?key",
+	staticRoute: '/',
+	dynamicRoute: '/dynamic',
+	'dynamicRoute/depth1': '/dynamic/:param1',
+	'dynamicRoute/depth1/depth2': '/dynamic/:param1/depth2/:param2',
+	constraintRoute: '/constraint',
+	'constraintRoute/param': '/constraint/param',
+	'constraintRoute/param/stringConstraint': '/constraint/param/:param<string>',
+	'constraintRoute/param/numberConstraint': '/constraint/param/:param<number>',
+	'constraintRoute/param/booleanConstraint':
+		'/constraint/param/:param<boolean>',
+	'constraintRoute/param/unionConstraint':
+		'/constraint/param/:param<(a|1|false)>',
+	'constraintRoute/searchParam': '/constraint/searchParam',
+	'constraintRoute/searchParam/stringConstraint':
+		'/constraint/searchParam?key<string>',
+	'constraintRoute/searchParam/numberConstraint':
+		'/constraint/searchParam?key<number>',
+	'constraintRoute/searchParam/booleanConstraint':
+		'/constraint/searchParam?key<boolean>',
+	'constraintRoute/searchParam/unionConstraint':
+		'/constraint/searchParam?key<(a|1|false)>',
+	withSearchParamsRoute: '/search',
+	'withSearchParamsRoute/singleParam': '/search?key',
+	'withSearchParamsRoute/multiParams': '/search?key1&key2',
+	'withSearchParamsRoute/optionalParam': '/search?key1?&key2',
+	mixRoute: '/mix',
+	'mixRoute/signle': '/mix/:param1?searchParam1',
+	'mixRoute/multipleParams': '/mix/:param2/:param3?searchParam1',
+	'mixRoute/multipleSearchParams': '/mix/:param3?searchParam1&searchParam2',
+	'mixRoute/nested': '/mix/nested?searchParam1',
+	'mixRoute/nested/depth1': '/mix/nested/:param1?searchParam2',
+	absoluteRoute: 'protocol://',
+	'absoluteRoute/domain': 'protocol://example.com',
+	'absoluteRoute/domain/static': 'protocol://example.com/staticPage',
+	'absoluteRoute/domain/withParam': 'protocol://example.com/:param?key',
 } as const satisfies FlatRoutes<typeof routeConfig>;
 
-Deno.test("format function test", () => {
-  const flatConfig = flattenRouteConfig(routeConfig);
+Deno.test('format function test', () => {
+	const flatConfig = flattenRouteConfig(routeConfig);
 
-  assertEquals(flatResult, flatConfig);
+	assertEquals(flatResult, flatConfig);
 });
 
-describe("generator function test", () => {
-  const flatConfig = flattenRouteConfig(routeConfig);
+describe('generator function test', () => {
+	const flatConfig = flattenRouteConfig(routeConfig);
 
-  const link = createLinkGenerator(flatConfig);
+	const link = createLinkGenerator(flatConfig);
 
-  it("static path", () => {
-    assertEquals("/", link("staticRoute"));
-  });
+	it('static path', () => {
+		assertEquals('/', link('staticRoute'));
+	});
 
-  describe("path with params", () => {
-    it("with single params", () => {
-      assertEquals(
-        "/dynamic/param1",
-        link("dynamicRoute/depth1", { param1: "param1" }),
-      );
-    });
+	describe('path with params', () => {
+		it('with single params', () => {
+			assertEquals(
+				'/dynamic/param1',
+				link('dynamicRoute/depth1', { param1: 'param1' })
+			);
+		});
 
-    it("with multiple params", () => {
-      assertEquals(
-        "/dynamic/dynamicPart1/depth2/dynamicPart2",
-        link("dynamicRoute/depth1/depth2", {
-          param1: "dynamicPart1",
-          param2: "dynamicPart2",
-        }),
-      );
-    });
+		it('with multiple params', () => {
+			assertEquals(
+				'/dynamic/dynamicPart1/depth2/dynamicPart2',
+				link('dynamicRoute/depth1/depth2', {
+					param1: 'dynamicPart1',
+					param2: 'dynamicPart2',
+				})
+			);
+		});
 
-    describe("params with constraint field", () => {
-      it("string constraint", () => {
-        assertEquals(
-          "/constraint/param/dynamicPart1",
-          link("constraintRoute/param/stringConstraint", {
-            param: "dynamicPart1",
-          }),
-        );
-      });
+		describe('params with constraint field', () => {
+			it('string constraint', () => {
+				assertEquals(
+					'/constraint/param/dynamicPart1',
+					link('constraintRoute/param/stringConstraint', {
+						param: 'dynamicPart1',
+					})
+				);
+			});
 
-      it("number constraint", () => {
-        assertEquals(
-          "/constraint/param/1",
-          link("constraintRoute/param/numberConstraint", { param: 1 }),
-        );
-      });
+			it('number constraint', () => {
+				assertEquals(
+					'/constraint/param/1',
+					link('constraintRoute/param/numberConstraint', { param: 1 })
+				);
+			});
 
-      it("boolean constraint", () => {
-        assertEquals(
-          "/constraint/param/true",
-          link("constraintRoute/param/booleanConstraint", {
-            param: true,
-          }),
-        );
-      });
+			it('boolean constraint', () => {
+				assertEquals(
+					'/constraint/param/true',
+					link('constraintRoute/param/booleanConstraint', {
+						param: true,
+					})
+				);
+			});
 
-      describe("Union constraint", () => {
-        it("Union constraint string element", () => {
-          assertEquals(
-            "/constraint/param/a",
-            link("constraintRoute/param/unionConstraint", {
-              param: "a",
-            }),
-          );
-        });
+			describe('Union constraint', () => {
+				it('Union constraint string element', () => {
+					assertEquals(
+						'/constraint/param/a',
+						link('constraintRoute/param/unionConstraint', {
+							param: 'a',
+						})
+					);
+				});
 
-        it("Union constraint number element", () => {
-          assertEquals(
-            "/constraint/param/1",
-            link("constraintRoute/param/numberConstraint", {
-              param: 1,
-            }),
-          );
-        });
+				it('Union constraint number element', () => {
+					assertEquals(
+						'/constraint/param/1',
+						link('constraintRoute/param/numberConstraint', {
+							param: 1,
+						})
+					);
+				});
 
-        it("Union constraint boolean element", () => {
-          assertEquals(
-            "/constraint/param/false",
-            link("constraintRoute/param/unionConstraint", {
-              param: false,
-            }),
-          );
-        });
-      });
-    });
-  });
+				it('Union constraint boolean element', () => {
+					assertEquals(
+						'/constraint/param/false',
+						link('constraintRoute/param/unionConstraint', {
+							param: false,
+						})
+					);
+				});
+			});
+		});
+	});
 
-  describe("path with search params", () => {
-    it("all search params have values set", () => {
-      assertEquals(
-        "/search?key=value",
-        link("withSearchParamsRoute/singleParam", undefined, { key: "value" }),
-      );
-    });
+	describe('path with search params', () => {
+		it('all search params have values set', () => {
+			assertEquals(
+				'/search?key=value',
+				link('withSearchParamsRoute/singleParam', undefined, { key: 'value' })
+			);
+		});
 
-    it("some search params have values set", () => {
-      assertEquals(
-        "/search?key1=value1&key2=value2",
-        link("withSearchParamsRoute/multiParams", undefined, {
-          key1: "value1",
-          key2: "value2",
-        }),
-      );
-    });
+		it('some search params have values set', () => {
+			assertEquals(
+				'/search?key1=value1&key2=value2',
+				link('withSearchParamsRoute/multiParams', undefined, {
+					key1: 'value1',
+					key2: 'value2',
+				})
+			);
+		});
 
-    it("optional search param have value set", () => {
-      assertEquals(
-        "/search?key1=value1&key2=value2",
-        link("withSearchParamsRoute/optionalParam", undefined, {
-          key1: "value1",
-          key2: "value2",
-        }),
-      );
-    });
+		it('optional search param have value set', () => {
+			assertEquals(
+				'/search?key1=value1&key2=value2',
+				link('withSearchParamsRoute/optionalParam', undefined, {
+					key1: 'value1',
+					key2: 'value2',
+				})
+			);
+		});
 
-    it("optional search param have not value set", () => {
-      assertEquals(
-        "/search?key2=value2",
-        link("withSearchParamsRoute/optionalParam", undefined, {
-          key2: "value2",
-        }),
-      );
-    });
+		it('optional search param have not value set', () => {
+			assertEquals(
+				'/search?key2=value2',
+				link('withSearchParamsRoute/optionalParam', undefined, {
+					key2: 'value2',
+				})
+			);
+		});
 
-    it("all search params have the value undefined", () => {
-      assertEquals(
-        "/search",
-        link("withSearchParamsRoute/multiParams", undefined),
-      );
-    });
+		it('all search params have the value undefined', () => {
+			assertEquals(
+				'/search',
+				link('withSearchParamsRoute/multiParams', undefined)
+			);
+		});
 
-    describe("search params with constraint filed", () => {
-      it("string constraint", () => {
-        assertEquals(
-          "/constraint/searchParam?key=value",
-          link("constraintRoute/searchParam/stringConstraint", undefined, {
-            key: "value",
-          }),
-        );
-      });
+		describe('search params with constraint filed', () => {
+			it('string constraint', () => {
+				assertEquals(
+					'/constraint/searchParam?key=value',
+					link('constraintRoute/searchParam/stringConstraint', undefined, {
+						key: 'value',
+					})
+				);
+			});
 
-      it("number constraint", () => {
-        assertEquals(
-          "/constraint/searchParam?key=1",
-          link("constraintRoute/searchParam/numberConstraint", undefined, {
-            key: 1,
-          }),
-        );
-      });
+			it('number constraint', () => {
+				assertEquals(
+					'/constraint/searchParam?key=1',
+					link('constraintRoute/searchParam/numberConstraint', undefined, {
+						key: 1,
+					})
+				);
+			});
 
-      it("boolean constraint", () => {
-        assertEquals(
-          "/constraint/searchParam?key=true",
-          link("constraintRoute/searchParam/booleanConstraint", undefined, {
-            key: true,
-          }),
-        );
-      });
-    });
-  });
+			it('boolean constraint', () => {
+				assertEquals(
+					'/constraint/searchParam?key=true',
+					link('constraintRoute/searchParam/booleanConstraint', undefined, {
+						key: true,
+					})
+				);
+			});
+		});
+	});
 
-  describe("absolute path", () => {
-    it("static page", () => {
-      assertEquals(
-        "protocol://example.com/staticPage",
-        link("absoluteRoute/domain/static"),
-      );
-    });
+	describe('absolute path', () => {
+		it('static page', () => {
+			assertEquals(
+				'protocol://example.com/staticPage',
+				link('absoluteRoute/domain/static')
+			);
+		});
 
-    it("with param and with search param", () => {
-      assertEquals(
-        "protocol://example.com/dynamicPage",
-        link("absoluteRoute/domain/withParam", { param: "dynamicPage" }),
-      );
-    });
+		it('with param and with search param', () => {
+			assertEquals(
+				'protocol://example.com/dynamicPage',
+				link('absoluteRoute/domain/withParam', { param: 'dynamicPage' })
+			);
+		});
 
-    it("with param and no search param", () => {
-      assertEquals(
-        "protocol://example.com/dynamicPage?key=value",
-        link(
-          "absoluteRoute/domain/withParam",
-          { param: "dynamicPage" },
-          {
-            key: "value",
-          },
-        ),
-      );
-    });
-  });
+		it('with param and no search param', () => {
+			assertEquals(
+				'protocol://example.com/dynamicPage?key=value',
+				link(
+					'absoluteRoute/domain/withParam',
+					{ param: 'dynamicPage' },
+					{
+						key: 'value',
+					}
+				)
+			);
+		});
+	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,350 +1,350 @@
-import { assertEquals } from '$std/assert/mod.ts';
-import { describe, it } from 'https://deno.land/std@0.224.0/testing/bdd.ts';
+import { assertEquals } from "$std/assert/mod.ts";
+import { describe, it } from "https://deno.land/std@0.224.0/testing/bdd.ts";
 import {
-	createLinkGenerator,
-	type FlatRoutes,
-	flattenRouteConfig,
-	type RouteConfig,
-} from '../src/mod.ts';
+  createLinkGenerator,
+  type FlatRoutes,
+  flattenRouteConfig,
+  type RouteConfig,
+} from "../src/mod.ts";
 
 const routeConfig = {
-	staticRoute: {
-		path: '/',
-	},
-	dynamicRoute: {
-		path: '/dynamic',
-		children: {
-			depth1: {
-				path: '/:param1',
-				children: {
-					depth2: {
-						path: '/depth2/:param2',
-					},
-				},
-			},
-		},
-	},
-	constraintRoute: {
-		path: '/constraint',
-		children: {
-			param: {
-				path: '/param',
-				children: {
-					stringConstraint: {
-						path: '/:param<string>',
-					},
-					numberConstraint: {
-						path: '/:param<number>',
-					},
-					booleanConstraint: {
-						path: '/:param<boolean>',
-					},
-					unionConstraint: {
-						path: '/:param<(a|1|false)>',
-					},
-				},
-			},
-			searchParam: {
-				path: '/searchParam',
-				children: {
-					stringConstraint: {
-						path: '?key<string>',
-					},
-					numberConstraint: {
-						path: '?key<number>',
-					},
-					booleanConstraint: {
-						path: '?key<boolean>',
-					},
-					unionConstraint: {
-						path: '?key<(a|1|false)>',
-					},
-				},
-			},
-		},
-	},
-	withSearchParamsRoute: {
-		path: '/search',
-		children: {
-			singleParam: {
-				path: '?key',
-			},
-			multiParams: {
-				path: '?key1&key2',
-			},
-			optionalParam: {
-				path: '?key1?&key2',
-			},
-		},
-	},
-	mixRoute: {
-		path: '/mix',
-		children: {
-			signle: {
-				path: '/:param1?searchParam1',
-			},
-			multipleParams: {
-				path: '/:param2/:param3?searchParam1',
-			},
-			multipleSearchParams: {
-				path: '/:param3?searchParam1&searchParam2',
-			},
-			nested: {
-				path: '/nested?searchParam1',
-				children: {
-					depth1: {
-						path: '/:param1?searchParam2',
-					},
-				},
-			},
-		},
-	},
-	absoluteRoute: {
-		path: 'protocol://',
-		children: {
-			domain: {
-				path: 'example.com',
-				children: {
-					static: {
-						path: '/staticPage',
-					},
-					withParam: {
-						path: '/:param?key',
-					},
-				},
-			},
-		},
-	},
+  staticRoute: {
+    path: "/",
+  },
+  dynamicRoute: {
+    path: "/dynamic",
+    children: {
+      depth1: {
+        path: "/:param1",
+        children: {
+          depth2: {
+            path: "/depth2/:param2",
+          },
+        },
+      },
+    },
+  },
+  constraintRoute: {
+    path: "/constraint",
+    children: {
+      param: {
+        path: "/param",
+        children: {
+          stringConstraint: {
+            path: "/:param<string>",
+          },
+          numberConstraint: {
+            path: "/:param<number>",
+          },
+          booleanConstraint: {
+            path: "/:param<boolean>",
+          },
+          unionConstraint: {
+            path: "/:param<(a|1|false)>",
+          },
+        },
+      },
+      searchParam: {
+        path: "/searchParam",
+        children: {
+          stringConstraint: {
+            path: "?key<string>",
+          },
+          numberConstraint: {
+            path: "?key<number>",
+          },
+          booleanConstraint: {
+            path: "?key<boolean>",
+          },
+          unionConstraint: {
+            path: "?key<(a|1|false)>",
+          },
+        },
+      },
+    },
+  },
+  withSearchParamsRoute: {
+    path: "/search",
+    children: {
+      singleParam: {
+        path: "?key",
+      },
+      multiParams: {
+        path: "?key1&key2",
+      },
+      optionalParam: {
+        path: "?key1?&key2",
+      },
+    },
+  },
+  mixRoute: {
+    path: "/mix",
+    children: {
+      signle: {
+        path: "/:param1?searchParam1",
+      },
+      multipleParams: {
+        path: "/:param2/:param3?searchParam1",
+      },
+      multipleSearchParams: {
+        path: "/:param3?searchParam1&searchParam2",
+      },
+      nested: {
+        path: "/nested?searchParam1",
+        children: {
+          depth1: {
+            path: "/:param1?searchParam2",
+          },
+        },
+      },
+    },
+  },
+  absoluteRoute: {
+    path: "protocol://",
+    children: {
+      domain: {
+        path: "example.com",
+        children: {
+          static: {
+            path: "/staticPage",
+          },
+          withParam: {
+            path: "/:param?key",
+          },
+        },
+      },
+    },
+  },
 } as const satisfies RouteConfig;
 
 const flatResult = {
-	staticRoute: '/',
-	dynamicRoute: '/dynamic',
-	'dynamicRoute/depth1': '/dynamic/:param1',
-	'dynamicRoute/depth1/depth2': '/dynamic/:param1/depth2/:param2',
-	constraintRoute: '/constraint',
-	'constraintRoute/param': '/constraint/param',
-	'constraintRoute/param/stringConstraint': '/constraint/param/:param<string>',
-	'constraintRoute/param/numberConstraint': '/constraint/param/:param<number>',
-	'constraintRoute/param/booleanConstraint':
-		'/constraint/param/:param<boolean>',
-	'constraintRoute/param/unionConstraint':
-		'/constraint/param/:param<(a|1|false)>',
-	'constraintRoute/searchParam': '/constraint/searchParam',
-	'constraintRoute/searchParam/stringConstraint':
-		'/constraint/searchParam?key<string>',
-	'constraintRoute/searchParam/numberConstraint':
-		'/constraint/searchParam?key<number>',
-	'constraintRoute/searchParam/booleanConstraint':
-		'/constraint/searchParam?key<boolean>',
-	'constraintRoute/searchParam/unionConstraint':
-		'/constraint/searchParam?key<(a|1|false)>',
-	withSearchParamsRoute: '/search',
-	'withSearchParamsRoute/singleParam': '/search?key',
-	'withSearchParamsRoute/multiParams': '/search?key1&key2',
-	'withSearchParamsRoute/optionalParam': '/search?key1?&key2',
-	mixRoute: '/mix',
-	'mixRoute/signle': '/mix/:param1?searchParam1',
-	'mixRoute/multipleParams': '/mix/:param2/:param3?searchParam1',
-	'mixRoute/multipleSearchParams': '/mix/:param3?searchParam1&searchParam2',
-	'mixRoute/nested': '/mix/nested?searchParam1',
-	'mixRoute/nested/depth1': '/mix/nested/:param1?searchParam2',
-	absoluteRoute: 'protocol://',
-	'absoluteRoute/domain': 'protocol://example.com',
-	'absoluteRoute/domain/static': 'protocol://example.com/staticPage',
-	'absoluteRoute/domain/withParam': 'protocol://example.com/:param?key',
+  staticRoute: "/",
+  dynamicRoute: "/dynamic",
+  "dynamicRoute/depth1": "/dynamic/:param1",
+  "dynamicRoute/depth1/depth2": "/dynamic/:param1/depth2/:param2",
+  constraintRoute: "/constraint",
+  "constraintRoute/param": "/constraint/param",
+  "constraintRoute/param/stringConstraint": "/constraint/param/:param<string>",
+  "constraintRoute/param/numberConstraint": "/constraint/param/:param<number>",
+  "constraintRoute/param/booleanConstraint":
+    "/constraint/param/:param<boolean>",
+  "constraintRoute/param/unionConstraint":
+    "/constraint/param/:param<(a|1|false)>",
+  "constraintRoute/searchParam": "/constraint/searchParam",
+  "constraintRoute/searchParam/stringConstraint":
+    "/constraint/searchParam?key<string>",
+  "constraintRoute/searchParam/numberConstraint":
+    "/constraint/searchParam?key<number>",
+  "constraintRoute/searchParam/booleanConstraint":
+    "/constraint/searchParam?key<boolean>",
+  "constraintRoute/searchParam/unionConstraint":
+    "/constraint/searchParam?key<(a|1|false)>",
+  withSearchParamsRoute: "/search",
+  "withSearchParamsRoute/singleParam": "/search?key",
+  "withSearchParamsRoute/multiParams": "/search?key1&key2",
+  "withSearchParamsRoute/optionalParam": "/search?key1?&key2",
+  mixRoute: "/mix",
+  "mixRoute/signle": "/mix/:param1?searchParam1",
+  "mixRoute/multipleParams": "/mix/:param2/:param3?searchParam1",
+  "mixRoute/multipleSearchParams": "/mix/:param3?searchParam1&searchParam2",
+  "mixRoute/nested": "/mix/nested?searchParam1",
+  "mixRoute/nested/depth1": "/mix/nested/:param1?searchParam2",
+  absoluteRoute: "protocol://",
+  "absoluteRoute/domain": "protocol://example.com",
+  "absoluteRoute/domain/static": "protocol://example.com/staticPage",
+  "absoluteRoute/domain/withParam": "protocol://example.com/:param?key",
 } as const satisfies FlatRoutes<typeof routeConfig>;
 
-Deno.test('format function test', () => {
-	const flatConfig = flattenRouteConfig(routeConfig);
+Deno.test("format function test", () => {
+  const flatConfig = flattenRouteConfig(routeConfig);
 
-	assertEquals(flatResult, flatConfig);
+  assertEquals(flatResult, flatConfig);
 });
 
-describe('generator function test', () => {
-	const flatConfig = flattenRouteConfig(routeConfig);
+describe("generator function test", () => {
+  const flatConfig = flattenRouteConfig(routeConfig);
 
-	const link = createLinkGenerator(flatConfig);
+  const link = createLinkGenerator(flatConfig);
 
-	it('static path', () => {
-		assertEquals('/', link('staticRoute'));
-	});
+  it("static path", () => {
+    assertEquals("/", link("staticRoute"));
+  });
 
-	describe('path with params', () => {
-		it('with single params', () => {
-			assertEquals(
-				'/dynamic/param1',
-				link('dynamicRoute/depth1', { param1: 'param1' })
-			);
-		});
+  describe("path with params", () => {
+    it("with single params", () => {
+      assertEquals(
+        "/dynamic/param1",
+        link("dynamicRoute/depth1", { param1: "param1" }),
+      );
+    });
 
-		it('with multiple params', () => {
-			assertEquals(
-				'/dynamic/dynamicPart1/depth2/dynamicPart2',
-				link('dynamicRoute/depth1/depth2', {
-					param1: 'dynamicPart1',
-					param2: 'dynamicPart2',
-				})
-			);
-		});
+    it("with multiple params", () => {
+      assertEquals(
+        "/dynamic/dynamicPart1/depth2/dynamicPart2",
+        link("dynamicRoute/depth1/depth2", {
+          param1: "dynamicPart1",
+          param2: "dynamicPart2",
+        }),
+      );
+    });
 
-		describe('params with constraint field', () => {
-			it('string constraint', () => {
-				assertEquals(
-					'/constraint/param/dynamicPart1',
-					link('constraintRoute/param/stringConstraint', {
-						param: 'dynamicPart1',
-					})
-				);
-			});
+    describe("params with constraint field", () => {
+      it("string constraint", () => {
+        assertEquals(
+          "/constraint/param/dynamicPart1",
+          link("constraintRoute/param/stringConstraint", {
+            param: "dynamicPart1",
+          }),
+        );
+      });
 
-			it('number constraint', () => {
-				assertEquals(
-					'/constraint/param/1',
-					link('constraintRoute/param/numberConstraint', { param: 1 })
-				);
-			});
+      it("number constraint", () => {
+        assertEquals(
+          "/constraint/param/1",
+          link("constraintRoute/param/numberConstraint", { param: 1 }),
+        );
+      });
 
-			it('boolean constraint', () => {
-				assertEquals(
-					'/constraint/param/true',
-					link('constraintRoute/param/booleanConstraint', {
-						param: true,
-					})
-				);
-			});
+      it("boolean constraint", () => {
+        assertEquals(
+          "/constraint/param/true",
+          link("constraintRoute/param/booleanConstraint", {
+            param: true,
+          }),
+        );
+      });
 
-			describe('Union constraint', () => {
-				it('Union constraint string element', () => {
-					assertEquals(
-						'/constraint/param/a',
-						link('constraintRoute/param/unionConstraint', {
-							param: 'a',
-						})
-					);
-				});
+      describe("Union constraint", () => {
+        it("Union constraint string element", () => {
+          assertEquals(
+            "/constraint/param/a",
+            link("constraintRoute/param/unionConstraint", {
+              param: "a",
+            }),
+          );
+        });
 
-				it('Union constraint number element', () => {
-					assertEquals(
-						'/constraint/param/1',
-						link('constraintRoute/param/numberConstraint', {
-							param: 1,
-						})
-					);
-				});
+        it("Union constraint number element", () => {
+          assertEquals(
+            "/constraint/param/1",
+            link("constraintRoute/param/numberConstraint", {
+              param: 1,
+            }),
+          );
+        });
 
-				it('Union constraint boolean element', () => {
-					assertEquals(
-						'/constraint/param/false',
-						link('constraintRoute/param/unionConstraint', {
-							param: false,
-						})
-					);
-				});
-			});
-		});
-	});
+        it("Union constraint boolean element", () => {
+          assertEquals(
+            "/constraint/param/false",
+            link("constraintRoute/param/unionConstraint", {
+              param: false,
+            }),
+          );
+        });
+      });
+    });
+  });
 
-	describe('path with search params', () => {
-		it('all search params have values set', () => {
-			assertEquals(
-				'/search?key=value',
-				link('withSearchParamsRoute/singleParam', undefined, { key: 'value' })
-			);
-		});
+  describe("path with search params", () => {
+    it("all search params have values set", () => {
+      assertEquals(
+        "/search?key=value",
+        link("withSearchParamsRoute/singleParam", undefined, { key: "value" }),
+      );
+    });
 
-		it('some search params have values set', () => {
-			assertEquals(
-				'/search?key1=value1&key2=value2',
-				link('withSearchParamsRoute/multiParams', undefined, {
-					key1: 'value1',
-					key2: 'value2',
-				})
-			);
-		});
+    it("some search params have values set", () => {
+      assertEquals(
+        "/search?key1=value1&key2=value2",
+        link("withSearchParamsRoute/multiParams", undefined, {
+          key1: "value1",
+          key2: "value2",
+        }),
+      );
+    });
 
-		it('optional search param have value set', () => {
-			assertEquals(
-				'/search?key1=value1&key2=value2',
-				link('withSearchParamsRoute/optionalParam', undefined, {
-					key1: 'value1',
-					key2: 'value2',
-				})
-			);
-		});
+    it("optional search param have value set", () => {
+      assertEquals(
+        "/search?key1=value1&key2=value2",
+        link("withSearchParamsRoute/optionalParam", undefined, {
+          key1: "value1",
+          key2: "value2",
+        }),
+      );
+    });
 
-		it('optional search param have not value set', () => {
-			assertEquals(
-				'/search?key2=value2',
-				link('withSearchParamsRoute/optionalParam', undefined, {
-					key2: 'value2',
-				})
-			);
-		});
+    it("optional search param have not value set", () => {
+      assertEquals(
+        "/search?key2=value2",
+        link("withSearchParamsRoute/optionalParam", undefined, {
+          key2: "value2",
+        }),
+      );
+    });
 
-		it('all search params have the value undefined', () => {
-			assertEquals(
-				'/search',
-				link('withSearchParamsRoute/multiParams', undefined)
-			);
-		});
+    it("all search params have the value undefined", () => {
+      assertEquals(
+        "/search",
+        link("withSearchParamsRoute/multiParams", undefined),
+      );
+    });
 
-		describe('search params with constraint filed', () => {
-			it('string constraint', () => {
-				assertEquals(
-					'/constraint/searchParam?key=value',
-					link('constraintRoute/searchParam/stringConstraint', undefined, {
-						key: 'value',
-					})
-				);
-			});
+    describe("search params with constraint filed", () => {
+      it("string constraint", () => {
+        assertEquals(
+          "/constraint/searchParam?key=value",
+          link("constraintRoute/searchParam/stringConstraint", undefined, {
+            key: "value",
+          }),
+        );
+      });
 
-			it('number constraint', () => {
-				assertEquals(
-					'/constraint/searchParam?key=1',
-					link('constraintRoute/searchParam/numberConstraint', undefined, {
-						key: 1,
-					})
-				);
-			});
+      it("number constraint", () => {
+        assertEquals(
+          "/constraint/searchParam?key=1",
+          link("constraintRoute/searchParam/numberConstraint", undefined, {
+            key: 1,
+          }),
+        );
+      });
 
-			it('boolean constraint', () => {
-				assertEquals(
-					'/constraint/searchParam?key=true',
-					link('constraintRoute/searchParam/booleanConstraint', undefined, {
-						key: true,
-					})
-				);
-			});
-		});
-	});
+      it("boolean constraint", () => {
+        assertEquals(
+          "/constraint/searchParam?key=true",
+          link("constraintRoute/searchParam/booleanConstraint", undefined, {
+            key: true,
+          }),
+        );
+      });
+    });
+  });
 
-	describe('absolute path', () => {
-		it('static page', () => {
-			assertEquals(
-				'protocol://example.com/staticPage',
-				link('absoluteRoute/domain/static')
-			);
-		});
+  describe("absolute path", () => {
+    it("static page", () => {
+      assertEquals(
+        "protocol://example.com/staticPage",
+        link("absoluteRoute/domain/static"),
+      );
+    });
 
-		it('with param and with search param', () => {
-			assertEquals(
-				'protocol://example.com/dynamicPage',
-				link('absoluteRoute/domain/withParam', { param: 'dynamicPage' })
-			);
-		});
+    it("with param and with search param", () => {
+      assertEquals(
+        "protocol://example.com/dynamicPage",
+        link("absoluteRoute/domain/withParam", { param: "dynamicPage" }),
+      );
+    });
 
-		it('with param and no search param', () => {
-			assertEquals(
-				'protocol://example.com/dynamicPage?key=value',
-				link(
-					'absoluteRoute/domain/withParam',
-					{ param: 'dynamicPage' },
-					{
-						key: 'value',
-					}
-				)
-			);
-		});
-	});
+    it("with param and no search param", () => {
+      assertEquals(
+        "protocol://example.com/dynamicPage?key=value",
+        link(
+          "absoluteRoute/domain/withParam",
+          { param: "dynamicPage" },
+          {
+            key: "value",
+          },
+        ),
+      );
+    });
+  });
 });


### PR DESCRIPTION
Corrected the inference for parameters in `ExtractRouteData` type. Previously, when there were no parameters, it returned `unknown`, which was incorrect. Now, it returns `never` for both `params` and `search` when no parameters are present.

Example:

Before:

```ts
type Route = { 'user': { path: '/user' } };

type UserRouteData = ExtractRouteData<Route>['user'];

// UserRouteData = { path: '/user', params: unknown, search: unknown };
```

After:

```ts
type Route = { 'user': { path: '/user' } };

type UserRouteData = ExtractRouteData<Route>['user'];

// UserRouteData = { path: '/user', params: never, search: never };
```
