### PR TITLE
refactor: rename queries to query

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,8 @@ import type { Symbols } from "./symbols.ts";
  * Each route has a path and optionally nested child routes.
  */
 type Route = {
-	path: string;
-	children?: RouteConfig;
+  path: string;
+  children?: RouteConfig;
 };
 
 /**
@@ -14,7 +14,7 @@ type Route = {
  * This type maps route IDs to their respective route definitions.
  */
 type RouteConfig = {
-	[routeId: string]: Route;
+  [routeId: string]: Route;
 };
 
 /**
@@ -26,38 +26,35 @@ type RouteConfig = {
  * @returns The generated link.
  */
 type LinkGenerator<Config extends FlatRouteConfig> = <
-	RouteId extends keyof Config
+  RouteId extends keyof Config,
 >(
-	routeId: RouteId,
-	...params: ParamArgs<Config, RouteId>
+  routeId: RouteId,
+  ...params: ParamArgs<Config, RouteId>
 ) => string;
 
 type FlatRouteConfig = Record<string, string>;
 
 type Split<
-	Source extends string,
-	Separator extends string
-> = string extends Source
-	? string[]
-	: Source extends ""
-	? []
-	: Source extends `${infer Before}${Separator}${infer After}`
-	? [Before, ...Split<After, Separator>]
-	: [Source];
+  Source extends string,
+  Separator extends string,
+> = string extends Source ? string[]
+  : Source extends "" ? []
+  : Source extends `${infer Before}${Separator}${infer After}`
+    ? [Before, ...Split<After, Separator>]
+  : [Source];
 
 type ParseSegment<Path extends string> = Split<Path, Symbols.PathSeparater>;
 
 type ParseQueryParams<QueryString extends string> = Split<
-	QueryString,
-	Symbols.QuerySeparator
+  QueryString,
+  Symbols.QuerySeparator
 >;
 
 // deno-lint-ignore no-explicit-any
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-	k: infer I
-) => void
-	? I
-	: never;
+  k: infer I,
+) => void ? I
+  : never;
 
 /**
  * The default value type for path or query parameters without constraints.
@@ -93,70 +90,63 @@ type DefaultParamValue = string | number | boolean;
 type Param = Record<string, DefaultParamValue>;
 
 type StringToBoolean<UnionSegment extends string> = UnionSegment extends "true"
-	? true
-	: UnionSegment extends "false"
-	? false
-	: UnionSegment;
+  ? true
+  : UnionSegment extends "false" ? false
+  : UnionSegment;
 
-type StringToNumber<UnionSegment extends string> =
-	UnionSegment extends `${infer NumericString extends number}`
-		? NumericString
-		: UnionSegment;
+type StringToNumber<UnionSegment extends string> = UnionSegment extends
+  `${infer NumericString extends number}` ? NumericString
+  : UnionSegment;
 
 type ParseUnion<UnionString extends string> = StringToBoolean<
-	StringToNumber<Split<UnionString, Symbols.UnionSeparater>[number]>
+  StringToNumber<Split<UnionString, Symbols.UnionSeparater>[number]>
 >;
 
 type InferParamType<Constraint extends string> = Constraint extends "string"
-	? string
-	: Constraint extends "number"
-	? number
-	: Constraint extends "boolean"
-	? boolean
-	: Constraint extends `${Symbols.UnionOpen}${infer Union}${Symbols.UnionClose}`
-	? ParseUnion<Union>
-	: never;
+  ? string
+  : Constraint extends "number" ? number
+  : Constraint extends "boolean" ? boolean
+  : Constraint extends `${Symbols.UnionOpen}${infer Union}${Symbols.UnionClose}`
+    ? ParseUnion<Union>
+  : never;
 
-type CreateParams<Segment extends string> =
-	Segment extends `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
-		? Record<ParamName, InferParamType<Constraint>>
-		: Record<Segment, DefaultParamValue>;
+type CreateParams<Segment extends string> = Segment extends
+  `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
+  ? Record<ParamName, InferParamType<Constraint>>
+  : Record<Segment, DefaultParamValue>;
 
-type ExtractParams<Segment> =
-	Segment extends `${Symbols.PathParam}${infer ParamField}`
-		? ParamField extends `${infer ParamName}${Symbols.Query}${string}`
-			? ParamName
-			: ParamField
-		: never;
+type ExtractParams<Segment> = Segment extends
+  `${Symbols.PathParam}${infer ParamField}`
+  ? ParamField extends `${infer ParamName}${Symbols.Query}${string}` ? ParamName
+  : ParamField
+  : never;
 
-type ExtractQueryArea<Path extends string> =
-	Path extends `${string}${Symbols.Query}${infer QueryString}`
-		? QueryString
-		: never;
+type ExtractQueryArea<Path extends string> = Path extends
+  `${string}${Symbols.Query}${infer QueryString}` ? QueryString
+  : never;
 
 type PathParams<Path extends string> = UnionToIntersection<
-	CreateParams<ExtractParams<ParseSegment<Path>[number]>>
+  CreateParams<ExtractParams<ParseSegment<Path>[number]>>
 >;
 
 type IsType<CheckType, TargetType> = CheckType extends TargetType
-	? TargetType extends CheckType
-		? true
-		: false
-	: false;
+  ? TargetType extends CheckType ? true
+  : false
+  : false;
 
 type IsUnknownType<T> = IsType<unknown, T>;
 
 type QueryParams<Path extends string> = UnionToIntersection<
-	CreateParams<ParseQueryParams<ExtractQueryArea<Path>>[number]>
+  CreateParams<ParseQueryParams<ExtractQueryArea<Path>>[number]>
 >;
 
-type RemoveQueryArea<Path extends string> =
-	Path extends `${infer RoutePath}?${string}` ? RoutePath : Path;
+type RemoveQueryArea<Path extends string> = Path extends
+  `${infer RoutePath}?${string}` ? RoutePath : Path;
 
-type RemoveConstraintArea<Path extends string> =
-	Path extends `${infer Head}${Symbols.ConstraintOpen}${string}${Symbols.ConstraintClose}${infer Tail}`
-		? RemoveConstraintArea<`${Head}${Tail}`>
-		: Path;
+type RemoveConstraintArea<Path extends string> = Path extends
+  `${infer Head}${Symbols.ConstraintOpen}${string}${Symbols.ConstraintClose}${infer Tail}`
+  ? RemoveConstraintArea<`${Head}${Tail}`>
+  : Path;
 
 /**
  * Extracts route data, including path and query parameters, for a given route configuration.
@@ -190,30 +180,28 @@ type RemoveConstraintArea<Path extends string> =
  * ```
  */
 type ExtractRouteData<FlattenedRoutes extends FlatRouteConfig> = {
-	[RouteId in keyof FlattenedRoutes]: {
-		path: RemoveConstraintArea<RemoveQueryArea<FlattenedRoutes[RouteId]>>;
-		params: IsUnknownType<PathParams<FlattenedRoutes[RouteId]>> extends true
-			? never
-			: PathParams<FlattenedRoutes[RouteId]>;
-		query: IsUnknownType<QueryParams<FlattenedRoutes[RouteId]>> extends true
-			? never
-			: Partial<QueryParams<FlattenedRoutes[RouteId]>>;
-	};
+  [RouteId in keyof FlattenedRoutes]: {
+    path: RemoveConstraintArea<RemoveQueryArea<FlattenedRoutes[RouteId]>>;
+    params: IsUnknownType<PathParams<FlattenedRoutes[RouteId]>> extends true
+      ? never
+      : PathParams<FlattenedRoutes[RouteId]>;
+    query: IsUnknownType<QueryParams<FlattenedRoutes[RouteId]>> extends true
+      ? never
+      : Partial<QueryParams<FlattenedRoutes[RouteId]>>;
+  };
 };
 
-type NestedKeys<Config> = Config extends RouteConfig
-	? {
-			[ParentKey in keyof Config]: ParentKey extends string
-				? Config[ParentKey] extends { children: RouteConfig }
-					?
-							| `${ParentKey}`
-							| `${ParentKey}${Symbols.PathSeparater}${NestedKeys<
-									Config[ParentKey]["children"]
-							  >}`
-					: ParentKey
-				: never;
-	  }[keyof Config]
-	: never;
+type NestedKeys<Config> = Config extends RouteConfig ? {
+    [ParentKey in keyof Config]: ParentKey extends string
+      ? Config[ParentKey] extends { children: RouteConfig } ?
+          | `${ParentKey}`
+          | `${ParentKey}${Symbols.PathSeparater}${NestedKeys<
+            Config[ParentKey]["children"]
+          >}`
+      : ParentKey
+      : never;
+  }[keyof Config]
+  : never;
 
 /**
  * Flattens the route configuration object into a simpler structure.
@@ -238,18 +226,18 @@ type NestedKeys<Config> = Config extends RouteConfig
  * ```
  */
 type FlattenRouteConfig<
-	Config,
-	ParentPath extends string = ""
-> = Config extends RouteConfig
-	? {
-			[RouteId in NestedKeys<Config>]: RouteId extends `${infer ParentRouteId}${Symbols.PathSeparater}${infer ChildrenRouteId}`
-				? FlattenRouteConfig<
-						Config[ParentRouteId]["children"],
-						`${ParentPath}${Config[ParentRouteId]["path"]}`
-				  >[ChildrenRouteId]
-				: `${ParentPath}${Config[RouteId]["path"]}`;
-	  }
-	: never;
+  Config,
+  ParentPath extends string = "",
+> = Config extends RouteConfig ? {
+    [RouteId in NestedKeys<Config>]: RouteId extends
+      `${infer ParentRouteId}${Symbols.PathSeparater}${infer ChildrenRouteId}`
+      ? FlattenRouteConfig<
+        Config[ParentRouteId]["children"],
+        `${ParentPath}${Config[ParentRouteId]["path"]}`
+      >[ChildrenRouteId]
+      : `${ParentPath}${Config[RouteId]["path"]}`;
+  }
+  : never;
 
 /**
  * Removes parent query area from a given route path.
@@ -264,10 +252,10 @@ type FlattenRouteConfig<
  * // => '/parentpath/childpath/?ckey1&ckey2' }
  * ```
  */
-type RemoveParentQueryArea<Path extends string> =
-	Path extends `${infer Head}${Symbols.Query}${string}${Symbols.PathSeparater}${infer Tail}`
-		? RemoveParentQueryArea<`${Head}${Symbols.PathSeparater}${Tail}`>
-		: Path;
+type RemoveParentQueryArea<Path extends string> = Path extends
+  `${infer Head}${Symbols.Query}${string}${Symbols.PathSeparater}${infer Tail}`
+  ? RemoveParentQueryArea<`${Head}${Symbols.PathSeparater}${Tail}`>
+  : Path;
 
 /**
  * Removes parent query string from the flattened route configuration.
@@ -304,13 +292,13 @@ type RemoveParentQueryArea<Path extends string> =
  * }
  * ```
  */
-type PrunePaths<Config> = Config extends FlatRouteConfig
-	? {
-			[RouteId in keyof Config]: Config[RouteId] extends `${infer Protocol}:/${infer Rest}` // Is absolute path?
-				? `${Protocol}:/${RemoveParentQueryArea<Rest>}`
-				: RemoveParentQueryArea<Config[RouteId]>;
-	  }
-	: never;
+type PrunePaths<Config> = Config extends FlatRouteConfig ? {
+    [RouteId in keyof Config]: Config[RouteId] extends
+      `${infer Protocol}:/${infer Rest}` // Is absolute path?
+      ? `${Protocol}:/${RemoveParentQueryArea<Rest>}`
+      : RemoveParentQueryArea<Config[RouteId]>;
+  }
+  : never;
 
 /**
  * Flattens the route configuration object.
@@ -355,25 +343,25 @@ type EmptyObject = Record<string, never>;
  * Extracts path and query parameters for a given route.
  */
 type ParamArgs<
-	Config extends FlatRouteConfig,
-	RouteId extends keyof Config
+  Config extends FlatRouteConfig,
+  RouteId extends keyof Config,
 > = ExtractRouteData<Config>[RouteId]["params"] extends EmptyObject
-	? [undefined?, ExtractRouteData<Config>[RouteId]["query"]?]
-	: IsUnknownType<ExtractRouteData<Config>[RouteId]["params"]> extends true
-	? [undefined?, ExtractRouteData<Config>[RouteId]["query"]?]
-	: [
-			ExtractRouteData<Config>[RouteId]["params"],
-			ExtractRouteData<Config>[RouteId]["query"]?
-	  ];
+  ? [undefined?, ExtractRouteData<Config>[RouteId]["query"]?]
+  : IsUnknownType<ExtractRouteData<Config>[RouteId]["params"]> extends true
+    ? [undefined?, ExtractRouteData<Config>[RouteId]["query"]?]
+  : [
+    ExtractRouteData<Config>[RouteId]["params"],
+    ExtractRouteData<Config>[RouteId]["query"]?,
+  ];
 
 export type {
-	DefaultParamValue,
-	ExtractRouteData,
-	FlatRouteConfig,
-	FlatRoutes,
-	LinkGenerator,
-	Param,
-	ParamArgs,
-	Route,
-	RouteConfig,
+  DefaultParamValue,
+  ExtractRouteData,
+  FlatRouteConfig,
+  FlatRoutes,
+  LinkGenerator,
+  Param,
+  ParamArgs,
+  Route,
+  RouteConfig,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,8 @@ import type { Symbols } from "./symbols.ts";
  * Each route has a path and optionally nested child routes.
  */
 type Route = {
-  path: string;
-  children?: RouteConfig;
+	path: string;
+	children?: RouteConfig;
 };
 
 /**
@@ -14,7 +14,7 @@ type Route = {
  * This type maps route IDs to their respective route definitions.
  */
 type RouteConfig = {
-  [routeId: string]: Route;
+	[routeId: string]: Route;
 };
 
 /**
@@ -26,35 +26,38 @@ type RouteConfig = {
  * @returns The generated link.
  */
 type LinkGenerator<Config extends FlatRouteConfig> = <
-  RouteId extends keyof Config,
+	RouteId extends keyof Config
 >(
-  routeId: RouteId,
-  ...params: ParamArgs<Config, RouteId>
+	routeId: RouteId,
+	...params: ParamArgs<Config, RouteId>
 ) => string;
 
 type FlatRouteConfig = Record<string, string>;
 
 type Split<
-  Source extends string,
-  Separator extends string,
-> = string extends Source ? string[]
-  : Source extends "" ? []
-  : Source extends `${infer Before}${Separator}${infer After}`
-    ? [Before, ...Split<After, Separator>]
-  : [Source];
+	Source extends string,
+	Separator extends string
+> = string extends Source
+	? string[]
+	: Source extends ""
+	? []
+	: Source extends `${infer Before}${Separator}${infer After}`
+	? [Before, ...Split<After, Separator>]
+	: [Source];
 
 type ParseSegment<Path extends string> = Split<Path, Symbols.PathSeparater>;
 
 type ParseQueryParams<QueryString extends string> = Split<
-  QueryString,
-  Symbols.QuerySeparator
+	QueryString,
+	Symbols.QuerySeparator
 >;
 
 // deno-lint-ignore no-explicit-any
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I,
-) => void ? I
-  : never;
+	k: infer I
+) => void
+	? I
+	: never;
 
 /**
  * The default value type for path or query parameters without constraints.
@@ -90,63 +93,70 @@ type DefaultParamValue = string | number | boolean;
 type Param = Record<string, DefaultParamValue>;
 
 type StringToBoolean<UnionSegment extends string> = UnionSegment extends "true"
-  ? true
-  : UnionSegment extends "false" ? false
-  : UnionSegment;
+	? true
+	: UnionSegment extends "false"
+	? false
+	: UnionSegment;
 
-type StringToNumber<UnionSegment extends string> = UnionSegment extends
-  `${infer NumericString extends number}` ? NumericString
-  : UnionSegment;
+type StringToNumber<UnionSegment extends string> =
+	UnionSegment extends `${infer NumericString extends number}`
+		? NumericString
+		: UnionSegment;
 
 type ParseUnion<UnionString extends string> = StringToBoolean<
-  StringToNumber<Split<UnionString, Symbols.UnionSeparater>[number]>
+	StringToNumber<Split<UnionString, Symbols.UnionSeparater>[number]>
 >;
 
 type InferParamType<Constraint extends string> = Constraint extends "string"
-  ? string
-  : Constraint extends "number" ? number
-  : Constraint extends "boolean" ? boolean
-  : Constraint extends `${Symbols.UnionOpen}${infer Union}${Symbols.UnionClose}`
-    ? ParseUnion<Union>
-  : never;
+	? string
+	: Constraint extends "number"
+	? number
+	: Constraint extends "boolean"
+	? boolean
+	: Constraint extends `${Symbols.UnionOpen}${infer Union}${Symbols.UnionClose}`
+	? ParseUnion<Union>
+	: never;
 
-type CreateParams<Segment extends string> = Segment extends
-  `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
-  ? Record<ParamName, InferParamType<Constraint>>
-  : Record<Segment, DefaultParamValue>;
+type CreateParams<Segment extends string> =
+	Segment extends `${infer ParamName}${Symbols.ConstraintOpen}${infer Constraint}${Symbols.ConstraintClose}`
+		? Record<ParamName, InferParamType<Constraint>>
+		: Record<Segment, DefaultParamValue>;
 
-type ExtractParams<Segment> = Segment extends
-  `${Symbols.PathParam}${infer ParamField}`
-  ? ParamField extends `${infer ParamName}${Symbols.Query}${string}` ? ParamName
-  : ParamField
-  : never;
+type ExtractParams<Segment> =
+	Segment extends `${Symbols.PathParam}${infer ParamField}`
+		? ParamField extends `${infer ParamName}${Symbols.Query}${string}`
+			? ParamName
+			: ParamField
+		: never;
 
-type ExtractQueryArea<Path extends string> = Path extends
-  `${string}${Symbols.Query}${infer QueryString}` ? QueryString
-  : never;
+type ExtractQueryArea<Path extends string> =
+	Path extends `${string}${Symbols.Query}${infer QueryString}`
+		? QueryString
+		: never;
 
 type PathParams<Path extends string> = UnionToIntersection<
-  CreateParams<ExtractParams<ParseSegment<Path>[number]>>
+	CreateParams<ExtractParams<ParseSegment<Path>[number]>>
 >;
 
 type IsType<CheckType, TargetType> = CheckType extends TargetType
-  ? TargetType extends CheckType ? true
-  : false
-  : false;
+	? TargetType extends CheckType
+		? true
+		: false
+	: false;
 
 type IsUnknownType<T> = IsType<unknown, T>;
 
 type QueryParams<Path extends string> = UnionToIntersection<
-  CreateParams<ParseQueryParams<ExtractQueryArea<Path>>[number]>
+	CreateParams<ParseQueryParams<ExtractQueryArea<Path>>[number]>
 >;
 
-type RemoveQueryArea<Path extends string> = Path extends
-  `${infer RoutePath}?${string}` ? RoutePath : Path;
+type RemoveQueryArea<Path extends string> =
+	Path extends `${infer RoutePath}?${string}` ? RoutePath : Path;
 
-type RemoveConstraintArea<Path extends string> = Path extends
-  `${infer Head}${Symbols.ConstraintOpen}${string}${Symbols.ConstraintClose}${infer Tail}`
-  ? RemoveConstraintArea<`${Head}${Tail}`>
-  : Path;
+type RemoveConstraintArea<Path extends string> =
+	Path extends `${infer Head}${Symbols.ConstraintOpen}${string}${Symbols.ConstraintClose}${infer Tail}`
+		? RemoveConstraintArea<`${Head}${Tail}`>
+		: Path;
 
 /**
  * Extracts route data, including path and query parameters, for a given route configuration.
@@ -180,28 +190,30 @@ type RemoveConstraintArea<Path extends string> = Path extends
  * ```
  */
 type ExtractRouteData<FlattenedRoutes extends FlatRouteConfig> = {
-  [RouteId in keyof FlattenedRoutes]: {
-    path: RemoveConstraintArea<RemoveQueryArea<FlattenedRoutes[RouteId]>>;
-    params: IsUnknownType<PathParams<FlattenedRoutes[RouteId]>> extends true
-      ? never
-      : PathParams<FlattenedRoutes[RouteId]>;
-    queries: IsUnknownType<QueryParams<FlattenedRoutes[RouteId]>> extends true
-      ? never
-      : Partial<QueryParams<FlattenedRoutes[RouteId]>>;
-  };
+	[RouteId in keyof FlattenedRoutes]: {
+		path: RemoveConstraintArea<RemoveQueryArea<FlattenedRoutes[RouteId]>>;
+		params: IsUnknownType<PathParams<FlattenedRoutes[RouteId]>> extends true
+			? never
+			: PathParams<FlattenedRoutes[RouteId]>;
+		query: IsUnknownType<QueryParams<FlattenedRoutes[RouteId]>> extends true
+			? never
+			: Partial<QueryParams<FlattenedRoutes[RouteId]>>;
+	};
 };
 
-type NestedKeys<Config> = Config extends RouteConfig ? {
-    [ParentKey in keyof Config]: ParentKey extends string
-      ? Config[ParentKey] extends { children: RouteConfig } ?
-          | `${ParentKey}`
-          | `${ParentKey}${Symbols.PathSeparater}${NestedKeys<
-            Config[ParentKey]["children"]
-          >}`
-      : ParentKey
-      : never;
-  }[keyof Config]
-  : never;
+type NestedKeys<Config> = Config extends RouteConfig
+	? {
+			[ParentKey in keyof Config]: ParentKey extends string
+				? Config[ParentKey] extends { children: RouteConfig }
+					?
+							| `${ParentKey}`
+							| `${ParentKey}${Symbols.PathSeparater}${NestedKeys<
+									Config[ParentKey]["children"]
+							  >}`
+					: ParentKey
+				: never;
+	  }[keyof Config]
+	: never;
 
 /**
  * Flattens the route configuration object into a simpler structure.
@@ -226,18 +238,18 @@ type NestedKeys<Config> = Config extends RouteConfig ? {
  * ```
  */
 type FlattenRouteConfig<
-  Config,
-  ParentPath extends string = "",
-> = Config extends RouteConfig ? {
-    [RouteId in NestedKeys<Config>]: RouteId extends
-      `${infer ParentRouteId}${Symbols.PathSeparater}${infer ChildrenRouteId}`
-      ? FlattenRouteConfig<
-        Config[ParentRouteId]["children"],
-        `${ParentPath}${Config[ParentRouteId]["path"]}`
-      >[ChildrenRouteId]
-      : `${ParentPath}${Config[RouteId]["path"]}`;
-  }
-  : never;
+	Config,
+	ParentPath extends string = ""
+> = Config extends RouteConfig
+	? {
+			[RouteId in NestedKeys<Config>]: RouteId extends `${infer ParentRouteId}${Symbols.PathSeparater}${infer ChildrenRouteId}`
+				? FlattenRouteConfig<
+						Config[ParentRouteId]["children"],
+						`${ParentPath}${Config[ParentRouteId]["path"]}`
+				  >[ChildrenRouteId]
+				: `${ParentPath}${Config[RouteId]["path"]}`;
+	  }
+	: never;
 
 /**
  * Removes parent query area from a given route path.
@@ -252,10 +264,10 @@ type FlattenRouteConfig<
  * // => '/parentpath/childpath/?ckey1&ckey2' }
  * ```
  */
-type RemoveParentQueryArea<Path extends string> = Path extends
-  `${infer Head}${Symbols.Query}${string}${Symbols.PathSeparater}${infer Tail}`
-  ? RemoveParentQueryArea<`${Head}${Symbols.PathSeparater}${Tail}`>
-  : Path;
+type RemoveParentQueryArea<Path extends string> =
+	Path extends `${infer Head}${Symbols.Query}${string}${Symbols.PathSeparater}${infer Tail}`
+		? RemoveParentQueryArea<`${Head}${Symbols.PathSeparater}${Tail}`>
+		: Path;
 
 /**
  * Removes parent query string from the flattened route configuration.
@@ -292,13 +304,13 @@ type RemoveParentQueryArea<Path extends string> = Path extends
  * }
  * ```
  */
-type PrunePaths<Config> = Config extends FlatRouteConfig ? {
-    [RouteId in keyof Config]: Config[RouteId] extends
-      `${infer Protocol}:/${infer Rest}` // Is absolute path?
-      ? `${Protocol}:/${RemoveParentQueryArea<Rest>}`
-      : RemoveParentQueryArea<Config[RouteId]>;
-  }
-  : never;
+type PrunePaths<Config> = Config extends FlatRouteConfig
+	? {
+			[RouteId in keyof Config]: Config[RouteId] extends `${infer Protocol}:/${infer Rest}` // Is absolute path?
+				? `${Protocol}:/${RemoveParentQueryArea<Rest>}`
+				: RemoveParentQueryArea<Config[RouteId]>;
+	  }
+	: never;
 
 /**
  * Flattens the route configuration object.
@@ -343,25 +355,25 @@ type EmptyObject = Record<string, never>;
  * Extracts path and query parameters for a given route.
  */
 type ParamArgs<
-  Config extends FlatRouteConfig,
-  RouteId extends keyof Config,
+	Config extends FlatRouteConfig,
+	RouteId extends keyof Config
 > = ExtractRouteData<Config>[RouteId]["params"] extends EmptyObject
-  ? [undefined?, ExtractRouteData<Config>[RouteId]["queries"]?]
-  : IsUnknownType<ExtractRouteData<Config>[RouteId]["params"]> extends true
-    ? [undefined?, ExtractRouteData<Config>[RouteId]["queries"]?]
-  : [
-    ExtractRouteData<Config>[RouteId]["params"],
-    ExtractRouteData<Config>[RouteId]["queries"]?,
-  ];
+	? [undefined?, ExtractRouteData<Config>[RouteId]["query"]?]
+	: IsUnknownType<ExtractRouteData<Config>[RouteId]["params"]> extends true
+	? [undefined?, ExtractRouteData<Config>[RouteId]["query"]?]
+	: [
+			ExtractRouteData<Config>[RouteId]["params"],
+			ExtractRouteData<Config>[RouteId]["query"]?
+	  ];
 
 export type {
-  DefaultParamValue,
-  ExtractRouteData,
-  FlatRouteConfig,
-  FlatRoutes,
-  LinkGenerator,
-  Param,
-  ParamArgs,
-  Route,
-  RouteConfig,
+	DefaultParamValue,
+	ExtractRouteData,
+	FlatRouteConfig,
+	FlatRoutes,
+	LinkGenerator,
+	Param,
+	ParamArgs,
+	Route,
+	RouteConfig,
 };

--- a/test/path_absolute.test.ts
+++ b/test/path_absolute.test.ts
@@ -1,114 +1,114 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-	create_link_generator,
-	type DefaultParamValue,
-	type ExtractRouteData,
-	type FlatRoutes,
-	flatten_route_config,
-	type RouteConfig,
+  create_link_generator,
+  type DefaultParamValue,
+  type ExtractRouteData,
+  type FlatRoutes,
+  flatten_route_config,
+  type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-	http: {
-		path: "http://",
-		children: {
-			localhost: {
-				path: "localhost:3000",
-				children: {
-					static: {
-						path: "/name",
-					},
-					with_param: {
-						path: "/:param",
-					},
-					with_query: {
-						path: "/name?key",
-					},
-				},
-			},
-		},
-	},
+  http: {
+    path: "http://",
+    children: {
+      localhost: {
+        path: "localhost:3000",
+        children: {
+          static: {
+            path: "/name",
+          },
+          with_param: {
+            path: "/:param",
+          },
+          with_query: {
+            path: "/name?key",
+          },
+        },
+      },
+    },
+  },
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-	type ExpectedFlatRoutes = {
-		http: "http://";
-		"http/localhost": "http://localhost:3000";
-		"http/localhost/static": "http://localhost:3000/name";
-		"http/localhost/with_param": "http://localhost:3000/:param";
-		"http/localhost/with_query": "http://localhost:3000/name?key";
-	};
+  type ExpectedFlatRoutes = {
+    http: "http://";
+    "http/localhost": "http://localhost:3000";
+    "http/localhost/static": "http://localhost:3000/name";
+    "http/localhost/with_param": "http://localhost:3000/:param";
+    "http/localhost/with_query": "http://localhost:3000/name?key";
+  };
 
-	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-		true
-	);
+  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+    true,
+  );
 });
 
 Deno.test("ExtractRouteData type", () => {
-	type ExpectedExtractRouteData = {
-		http: {
-			path: "http://";
-			params: never;
-			query: never;
-		};
-		"http/localhost": {
-			path: "http://localhost:3000";
-			params: never;
-			query: never;
-		};
-		"http/localhost/static": {
-			path: "http://localhost:3000/name";
-			params: never;
-			query: never;
-		};
-		"http/localhost/with_param": {
-			path: "http://localhost:3000/:param";
-			params: Record<"param", DefaultParamValue>;
-			query: never;
-		};
-		"http/localhost/with_query": {
-			path: "http://localhost:3000/name";
-			params: never;
-			query: Partial<Record<"key", DefaultParamValue>>;
-		};
-	};
+  type ExpectedExtractRouteData = {
+    http: {
+      path: "http://";
+      params: never;
+      query: never;
+    };
+    "http/localhost": {
+      path: "http://localhost:3000";
+      params: never;
+      query: never;
+    };
+    "http/localhost/static": {
+      path: "http://localhost:3000/name";
+      params: never;
+      query: never;
+    };
+    "http/localhost/with_param": {
+      path: "http://localhost:3000/:param";
+      params: Record<"param", DefaultParamValue>;
+      query: never;
+    };
+    "http/localhost/with_query": {
+      path: "http://localhost:3000/name";
+      params: never;
+      query: Partial<Record<"key", DefaultParamValue>>;
+    };
+  };
 
-	assertType<
-		IsExact<
-			ExtractRouteData<typeof flat_route_config>,
-			ExpectedExtractRouteData
-		>
-	>(true);
+  assertType<
+    IsExact<
+      ExtractRouteData<typeof flat_route_config>,
+      ExpectedExtractRouteData
+    >
+  >(true);
 });
 
 Deno.test("flatten_route_config", () => {
-	const expected_flat_route_config = {
-		http: "http://",
-		"http/localhost": "http://localhost:3000",
-		"http/localhost/static": "http://localhost:3000/name",
-		"http/localhost/with_param": "http://localhost:3000/:param",
-		"http/localhost/with_query": "http://localhost:3000/name?key",
-	} as const satisfies FlatRoutes<typeof route_config>;
+  const expected_flat_route_config = {
+    http: "http://",
+    "http/localhost": "http://localhost:3000",
+    "http/localhost/static": "http://localhost:3000/name",
+    "http/localhost/with_param": "http://localhost:3000/:param",
+    "http/localhost/with_query": "http://localhost:3000/name?key",
+  } as const satisfies FlatRoutes<typeof route_config>;
 
-	assertEquals(flat_route_config, expected_flat_route_config);
+  assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", () => {
-	const link = create_link_generator(flat_route_config);
-	const protocol = link("http");
-	const path_to_localhost = link("http/localhost");
-	const path_to_static = link("http/localhost/static");
-	const path_to_with_param = link("http/localhost/with_param", { param: "a" });
-	const path_to_with_query = link("http/localhost/with_query", undefined, {
-		key: "a",
-	});
+  const link = create_link_generator(flat_route_config);
+  const protocol = link("http");
+  const path_to_localhost = link("http/localhost");
+  const path_to_static = link("http/localhost/static");
+  const path_to_with_param = link("http/localhost/with_param", { param: "a" });
+  const path_to_with_query = link("http/localhost/with_query", undefined, {
+    key: "a",
+  });
 
-	assertEquals(protocol, "http://");
-	assertEquals(path_to_localhost, "http://localhost:3000");
-	assertEquals(path_to_static, "http://localhost:3000/name");
-	assertEquals(path_to_with_param, "http://localhost:3000/a");
-	assertEquals(path_to_with_query, "http://localhost:3000/name?key=a");
+  assertEquals(protocol, "http://");
+  assertEquals(path_to_localhost, "http://localhost:3000");
+  assertEquals(path_to_static, "http://localhost:3000/name");
+  assertEquals(path_to_with_param, "http://localhost:3000/a");
+  assertEquals(path_to_with_query, "http://localhost:3000/name?key=a");
 });

--- a/test/path_absolute.test.ts
+++ b/test/path_absolute.test.ts
@@ -1,114 +1,114 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-  create_link_generator,
-  type DefaultParamValue,
-  type ExtractRouteData,
-  type FlatRoutes,
-  flatten_route_config,
-  type RouteConfig,
+	create_link_generator,
+	type DefaultParamValue,
+	type ExtractRouteData,
+	type FlatRoutes,
+	flatten_route_config,
+	type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-  http: {
-    path: "http://",
-    children: {
-      localhost: {
-        path: "localhost:3000",
-        children: {
-          static: {
-            path: "/name",
-          },
-          with_param: {
-            path: "/:param",
-          },
-          with_query: {
-            path: "/name?key",
-          },
-        },
-      },
-    },
-  },
+	http: {
+		path: "http://",
+		children: {
+			localhost: {
+				path: "localhost:3000",
+				children: {
+					static: {
+						path: "/name",
+					},
+					with_param: {
+						path: "/:param",
+					},
+					with_query: {
+						path: "/name?key",
+					},
+				},
+			},
+		},
+	},
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-  type ExpectedFlatRoutes = {
-    http: "http://";
-    "http/localhost": "http://localhost:3000";
-    "http/localhost/static": "http://localhost:3000/name";
-    "http/localhost/with_param": "http://localhost:3000/:param";
-    "http/localhost/with_query": "http://localhost:3000/name?key";
-  };
+	type ExpectedFlatRoutes = {
+		http: "http://";
+		"http/localhost": "http://localhost:3000";
+		"http/localhost/static": "http://localhost:3000/name";
+		"http/localhost/with_param": "http://localhost:3000/:param";
+		"http/localhost/with_query": "http://localhost:3000/name?key";
+	};
 
-  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-    true,
-  );
+	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+		true
+	);
 });
 
 Deno.test("ExtractRouteData type", () => {
-  type ExpectedExtractRouteData = {
-    http: {
-      path: "http://";
-      params: never;
-      queries: never;
-    };
-    "http/localhost": {
-      path: "http://localhost:3000";
-      params: never;
-      queries: never;
-    };
-    "http/localhost/static": {
-      path: "http://localhost:3000/name";
-      params: never;
-      queries: never;
-    };
-    "http/localhost/with_param": {
-      path: "http://localhost:3000/:param";
-      params: Record<"param", DefaultParamValue>;
-      queries: never;
-    };
-    "http/localhost/with_query": {
-      path: "http://localhost:3000/name";
-      params: never;
-      queries: Partial<Record<"key", DefaultParamValue>>;
-    };
-  };
+	type ExpectedExtractRouteData = {
+		http: {
+			path: "http://";
+			params: never;
+			query: never;
+		};
+		"http/localhost": {
+			path: "http://localhost:3000";
+			params: never;
+			query: never;
+		};
+		"http/localhost/static": {
+			path: "http://localhost:3000/name";
+			params: never;
+			query: never;
+		};
+		"http/localhost/with_param": {
+			path: "http://localhost:3000/:param";
+			params: Record<"param", DefaultParamValue>;
+			query: never;
+		};
+		"http/localhost/with_query": {
+			path: "http://localhost:3000/name";
+			params: never;
+			query: Partial<Record<"key", DefaultParamValue>>;
+		};
+	};
 
-  assertType<
-    IsExact<
-      ExtractRouteData<typeof flat_route_config>,
-      ExpectedExtractRouteData
-    >
-  >(true);
+	assertType<
+		IsExact<
+			ExtractRouteData<typeof flat_route_config>,
+			ExpectedExtractRouteData
+		>
+	>(true);
 });
 
 Deno.test("flatten_route_config", () => {
-  const expected_flat_route_config = {
-    http: "http://",
-    "http/localhost": "http://localhost:3000",
-    "http/localhost/static": "http://localhost:3000/name",
-    "http/localhost/with_param": "http://localhost:3000/:param",
-    "http/localhost/with_query": "http://localhost:3000/name?key",
-  } as const satisfies FlatRoutes<typeof route_config>;
+	const expected_flat_route_config = {
+		http: "http://",
+		"http/localhost": "http://localhost:3000",
+		"http/localhost/static": "http://localhost:3000/name",
+		"http/localhost/with_param": "http://localhost:3000/:param",
+		"http/localhost/with_query": "http://localhost:3000/name?key",
+	} as const satisfies FlatRoutes<typeof route_config>;
 
-  assertEquals(flat_route_config, expected_flat_route_config);
+	assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", () => {
-  const link = create_link_generator(flat_route_config);
-  const protocol = link("http");
-  const path_to_localhost = link("http/localhost");
-  const path_to_static = link("http/localhost/static");
-  const path_to_with_param = link("http/localhost/with_param", { param: "a" });
-  const path_to_with_query = link("http/localhost/with_query", undefined, {
-    key: "a",
-  });
+	const link = create_link_generator(flat_route_config);
+	const protocol = link("http");
+	const path_to_localhost = link("http/localhost");
+	const path_to_static = link("http/localhost/static");
+	const path_to_with_param = link("http/localhost/with_param", { param: "a" });
+	const path_to_with_query = link("http/localhost/with_query", undefined, {
+		key: "a",
+	});
 
-  assertEquals(protocol, "http://");
-  assertEquals(path_to_localhost, "http://localhost:3000");
-  assertEquals(path_to_static, "http://localhost:3000/name");
-  assertEquals(path_to_with_param, "http://localhost:3000/a");
-  assertEquals(path_to_with_query, "http://localhost:3000/name?key=a");
+	assertEquals(protocol, "http://");
+	assertEquals(path_to_localhost, "http://localhost:3000");
+	assertEquals(path_to_static, "http://localhost:3000/name");
+	assertEquals(path_to_with_param, "http://localhost:3000/a");
+	assertEquals(path_to_with_query, "http://localhost:3000/name?key=a");
 });

--- a/test/path_constraint.test.ts
+++ b/test/path_constraint.test.ts
@@ -1,171 +1,171 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-  create_link_generator,
-  type ExtractRouteData,
-  type FlatRoutes,
-  flatten_route_config,
-  type RouteConfig,
+	create_link_generator,
+	type ExtractRouteData,
+	type FlatRoutes,
+	flatten_route_config,
+	type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-  string_param: {
-    path: "/:param<string>",
-  },
-  number_param: {
-    path: "/:param<number>",
-  },
-  boolean_param: {
-    path: "/:param<boolean>",
-  },
-  string_query: {
-    path: "/?key<string>",
-  },
-  number_query: {
-    path: "/?key<number>",
-  },
-  boolean_query: {
-    path: "/?key<boolean>",
-  },
-  strings_union_param: {
-    path: "/:param<(a|b|c)>",
-  },
-  numbers_union_param: {
-    path: "/:param<(1|2|3)>",
-  },
-  mix_union_param: {
-    path: "/:param<(a|1|true)>",
-  },
-  strings_union_query: {
-    path: "/?key<(a|b|c)>",
-  },
-  numbers_union_query: {
-    path: "/?key<(1|2|3)>",
-  },
-  mix_union_query: {
-    path: "/?key<(a|1|true)>",
-  },
+	string_param: {
+		path: "/:param<string>",
+	},
+	number_param: {
+		path: "/:param<number>",
+	},
+	boolean_param: {
+		path: "/:param<boolean>",
+	},
+	string_query: {
+		path: "/?key<string>",
+	},
+	number_query: {
+		path: "/?key<number>",
+	},
+	boolean_query: {
+		path: "/?key<boolean>",
+	},
+	strings_union_param: {
+		path: "/:param<(a|b|c)>",
+	},
+	numbers_union_param: {
+		path: "/:param<(1|2|3)>",
+	},
+	mix_union_param: {
+		path: "/:param<(a|1|true)>",
+	},
+	strings_union_query: {
+		path: "/?key<(a|b|c)>",
+	},
+	numbers_union_query: {
+		path: "/?key<(1|2|3)>",
+	},
+	mix_union_query: {
+		path: "/?key<(a|1|true)>",
+	},
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-  type ExpectedFlatRoutes = {
-    string_param: "/:param<string>";
-    number_param: "/:param<number>";
-    boolean_param: "/:param<boolean>";
-    string_query: "/?key<string>";
-    number_query: "/?key<number>";
-    boolean_query: "/?key<boolean>";
-    strings_union_param: "/:param<(a|b|c)>";
-    numbers_union_param: "/:param<(1|2|3)>";
-    mix_union_param: "/:param<(a|1|true)>";
-    strings_union_query: "/?key<(a|b|c)>";
-    numbers_union_query: "/?key<(1|2|3)>";
-    mix_union_query: "/?key<(a|1|true)>";
-  };
+	type ExpectedFlatRoutes = {
+		string_param: "/:param<string>";
+		number_param: "/:param<number>";
+		boolean_param: "/:param<boolean>";
+		string_query: "/?key<string>";
+		number_query: "/?key<number>";
+		boolean_query: "/?key<boolean>";
+		strings_union_param: "/:param<(a|b|c)>";
+		numbers_union_param: "/:param<(1|2|3)>";
+		mix_union_param: "/:param<(a|1|true)>";
+		strings_union_query: "/?key<(a|b|c)>";
+		numbers_union_query: "/?key<(1|2|3)>";
+		mix_union_query: "/?key<(a|1|true)>";
+	};
 
-  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-    true,
-  );
+	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+		true
+	);
 });
 
 Deno.test("ExtractRouteData type", () => {
-  type ExpectedExtractRouteData = {
-    string_param: {
-      path: "/:param";
-      params: Record<"param", string>;
-      queries: never;
-    };
-    number_param: {
-      path: "/:param";
-      params: Record<"param", number>;
-      queries: never;
-    };
-    boolean_param: {
-      path: "/:param";
-      params: Record<"param", boolean>;
-      queries: never;
-    };
-    string_query: {
-      path: "/";
-      params: never;
-      queries: Partial<Record<"key", string>>;
-    };
-    number_query: {
-      path: "/";
-      params: never;
-      queries: Partial<Record<"key", number>>;
-    };
-    boolean_query: {
-      path: "/";
-      params: never;
-      queries: Partial<Record<"key", boolean>>;
-    };
-    strings_union_param: {
-      path: "/:param";
-      params: Record<"param", "a" | "b" | "c">;
-      queries: never;
-    };
-    numbers_union_param: {
-      path: "/:param";
-      params: Record<"param", 1 | 2 | 3>;
-      queries: never;
-    };
-    mix_union_param: {
-      path: "/:param";
-      params: Record<"param", "a" | 1 | true>;
-      queries: never;
-    };
-    strings_union_query: {
-      path: "/";
-      params: never;
-      queries: Partial<Record<"key", "a" | "b" | "c">>;
-    };
-    numbers_union_query: {
-      path: "/";
-      params: never;
-      queries: Partial<Record<"key", 1 | 2 | 3>>;
-    };
-    mix_union_query: {
-      path: "/";
-      params: never;
-      queries: Partial<Record<"key", "a" | 1 | true>>;
-    };
-  };
+	type ExpectedExtractRouteData = {
+		string_param: {
+			path: "/:param";
+			params: Record<"param", string>;
+			query: never;
+		};
+		number_param: {
+			path: "/:param";
+			params: Record<"param", number>;
+			query: never;
+		};
+		boolean_param: {
+			path: "/:param";
+			params: Record<"param", boolean>;
+			query: never;
+		};
+		string_query: {
+			path: "/";
+			params: never;
+			query: Partial<Record<"key", string>>;
+		};
+		number_query: {
+			path: "/";
+			params: never;
+			query: Partial<Record<"key", number>>;
+		};
+		boolean_query: {
+			path: "/";
+			params: never;
+			query: Partial<Record<"key", boolean>>;
+		};
+		strings_union_param: {
+			path: "/:param";
+			params: Record<"param", "a" | "b" | "c">;
+			query: never;
+		};
+		numbers_union_param: {
+			path: "/:param";
+			params: Record<"param", 1 | 2 | 3>;
+			query: never;
+		};
+		mix_union_param: {
+			path: "/:param";
+			params: Record<"param", "a" | 1 | true>;
+			query: never;
+		};
+		strings_union_query: {
+			path: "/";
+			params: never;
+			query: Partial<Record<"key", "a" | "b" | "c">>;
+		};
+		numbers_union_query: {
+			path: "/";
+			params: never;
+			query: Partial<Record<"key", 1 | 2 | 3>>;
+		};
+		mix_union_query: {
+			path: "/";
+			params: never;
+			query: Partial<Record<"key", "a" | 1 | true>>;
+		};
+	};
 
-  assertType<
-    IsExact<
-      ExtractRouteData<typeof flat_route_config>,
-      ExpectedExtractRouteData
-    >
-  >(true);
+	assertType<
+		IsExact<
+			ExtractRouteData<typeof flat_route_config>,
+			ExpectedExtractRouteData
+		>
+	>(true);
 });
 
 Deno.test("flatten_route_config", () => {
-  const expected_flat_route_config = {
-    string_param: "/:param<string>",
-    number_param: "/:param<number>",
-    boolean_param: "/:param<boolean>",
-    string_query: "/?key<string>",
-    number_query: "/?key<number>",
-    boolean_query: "/?key<boolean>",
-    strings_union_param: "/:param<(a|b|c)>",
-    numbers_union_param: "/:param<(1|2|3)>",
-    mix_union_param: "/:param<(a|1|true)>",
-    strings_union_query: "/?key<(a|b|c)>",
-    numbers_union_query: "/?key<(1|2|3)>",
-    mix_union_query: "/?key<(a|1|true)>",
-  } as const satisfies FlatRoutes<typeof route_config>;
+	const expected_flat_route_config = {
+		string_param: "/:param<string>",
+		number_param: "/:param<number>",
+		boolean_param: "/:param<boolean>",
+		string_query: "/?key<string>",
+		number_query: "/?key<number>",
+		boolean_query: "/?key<boolean>",
+		strings_union_param: "/:param<(a|b|c)>",
+		numbers_union_param: "/:param<(1|2|3)>",
+		mix_union_param: "/:param<(a|1|true)>",
+		strings_union_query: "/?key<(a|b|c)>",
+		numbers_union_query: "/?key<(1|2|3)>",
+		mix_union_query: "/?key<(a|1|true)>",
+	} as const satisfies FlatRoutes<typeof route_config>;
 
-  assertEquals(flat_route_config, expected_flat_route_config);
+	assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test(
-  "The constraint area should be removed when creating the path",
-  () => {
-    const link = create_link_generator(flat_route_config);
-    const path = link("string_param", { param: "a" });
-    assertEquals(path, "/a");
-  },
+	"The constraint area should be removed when creating the path",
+	() => {
+		const link = create_link_generator(flat_route_config);
+		const path = link("string_param", { param: "a" });
+		assertEquals(path, "/a");
+	}
 );

--- a/test/path_constraint.test.ts
+++ b/test/path_constraint.test.ts
@@ -1,171 +1,171 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-	create_link_generator,
-	type ExtractRouteData,
-	type FlatRoutes,
-	flatten_route_config,
-	type RouteConfig,
+  create_link_generator,
+  type ExtractRouteData,
+  type FlatRoutes,
+  flatten_route_config,
+  type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-	string_param: {
-		path: "/:param<string>",
-	},
-	number_param: {
-		path: "/:param<number>",
-	},
-	boolean_param: {
-		path: "/:param<boolean>",
-	},
-	string_query: {
-		path: "/?key<string>",
-	},
-	number_query: {
-		path: "/?key<number>",
-	},
-	boolean_query: {
-		path: "/?key<boolean>",
-	},
-	strings_union_param: {
-		path: "/:param<(a|b|c)>",
-	},
-	numbers_union_param: {
-		path: "/:param<(1|2|3)>",
-	},
-	mix_union_param: {
-		path: "/:param<(a|1|true)>",
-	},
-	strings_union_query: {
-		path: "/?key<(a|b|c)>",
-	},
-	numbers_union_query: {
-		path: "/?key<(1|2|3)>",
-	},
-	mix_union_query: {
-		path: "/?key<(a|1|true)>",
-	},
+  string_param: {
+    path: "/:param<string>",
+  },
+  number_param: {
+    path: "/:param<number>",
+  },
+  boolean_param: {
+    path: "/:param<boolean>",
+  },
+  string_query: {
+    path: "/?key<string>",
+  },
+  number_query: {
+    path: "/?key<number>",
+  },
+  boolean_query: {
+    path: "/?key<boolean>",
+  },
+  strings_union_param: {
+    path: "/:param<(a|b|c)>",
+  },
+  numbers_union_param: {
+    path: "/:param<(1|2|3)>",
+  },
+  mix_union_param: {
+    path: "/:param<(a|1|true)>",
+  },
+  strings_union_query: {
+    path: "/?key<(a|b|c)>",
+  },
+  numbers_union_query: {
+    path: "/?key<(1|2|3)>",
+  },
+  mix_union_query: {
+    path: "/?key<(a|1|true)>",
+  },
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-	type ExpectedFlatRoutes = {
-		string_param: "/:param<string>";
-		number_param: "/:param<number>";
-		boolean_param: "/:param<boolean>";
-		string_query: "/?key<string>";
-		number_query: "/?key<number>";
-		boolean_query: "/?key<boolean>";
-		strings_union_param: "/:param<(a|b|c)>";
-		numbers_union_param: "/:param<(1|2|3)>";
-		mix_union_param: "/:param<(a|1|true)>";
-		strings_union_query: "/?key<(a|b|c)>";
-		numbers_union_query: "/?key<(1|2|3)>";
-		mix_union_query: "/?key<(a|1|true)>";
-	};
+  type ExpectedFlatRoutes = {
+    string_param: "/:param<string>";
+    number_param: "/:param<number>";
+    boolean_param: "/:param<boolean>";
+    string_query: "/?key<string>";
+    number_query: "/?key<number>";
+    boolean_query: "/?key<boolean>";
+    strings_union_param: "/:param<(a|b|c)>";
+    numbers_union_param: "/:param<(1|2|3)>";
+    mix_union_param: "/:param<(a|1|true)>";
+    strings_union_query: "/?key<(a|b|c)>";
+    numbers_union_query: "/?key<(1|2|3)>";
+    mix_union_query: "/?key<(a|1|true)>";
+  };
 
-	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-		true
-	);
+  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+    true,
+  );
 });
 
 Deno.test("ExtractRouteData type", () => {
-	type ExpectedExtractRouteData = {
-		string_param: {
-			path: "/:param";
-			params: Record<"param", string>;
-			query: never;
-		};
-		number_param: {
-			path: "/:param";
-			params: Record<"param", number>;
-			query: never;
-		};
-		boolean_param: {
-			path: "/:param";
-			params: Record<"param", boolean>;
-			query: never;
-		};
-		string_query: {
-			path: "/";
-			params: never;
-			query: Partial<Record<"key", string>>;
-		};
-		number_query: {
-			path: "/";
-			params: never;
-			query: Partial<Record<"key", number>>;
-		};
-		boolean_query: {
-			path: "/";
-			params: never;
-			query: Partial<Record<"key", boolean>>;
-		};
-		strings_union_param: {
-			path: "/:param";
-			params: Record<"param", "a" | "b" | "c">;
-			query: never;
-		};
-		numbers_union_param: {
-			path: "/:param";
-			params: Record<"param", 1 | 2 | 3>;
-			query: never;
-		};
-		mix_union_param: {
-			path: "/:param";
-			params: Record<"param", "a" | 1 | true>;
-			query: never;
-		};
-		strings_union_query: {
-			path: "/";
-			params: never;
-			query: Partial<Record<"key", "a" | "b" | "c">>;
-		};
-		numbers_union_query: {
-			path: "/";
-			params: never;
-			query: Partial<Record<"key", 1 | 2 | 3>>;
-		};
-		mix_union_query: {
-			path: "/";
-			params: never;
-			query: Partial<Record<"key", "a" | 1 | true>>;
-		};
-	};
+  type ExpectedExtractRouteData = {
+    string_param: {
+      path: "/:param";
+      params: Record<"param", string>;
+      query: never;
+    };
+    number_param: {
+      path: "/:param";
+      params: Record<"param", number>;
+      query: never;
+    };
+    boolean_param: {
+      path: "/:param";
+      params: Record<"param", boolean>;
+      query: never;
+    };
+    string_query: {
+      path: "/";
+      params: never;
+      query: Partial<Record<"key", string>>;
+    };
+    number_query: {
+      path: "/";
+      params: never;
+      query: Partial<Record<"key", number>>;
+    };
+    boolean_query: {
+      path: "/";
+      params: never;
+      query: Partial<Record<"key", boolean>>;
+    };
+    strings_union_param: {
+      path: "/:param";
+      params: Record<"param", "a" | "b" | "c">;
+      query: never;
+    };
+    numbers_union_param: {
+      path: "/:param";
+      params: Record<"param", 1 | 2 | 3>;
+      query: never;
+    };
+    mix_union_param: {
+      path: "/:param";
+      params: Record<"param", "a" | 1 | true>;
+      query: never;
+    };
+    strings_union_query: {
+      path: "/";
+      params: never;
+      query: Partial<Record<"key", "a" | "b" | "c">>;
+    };
+    numbers_union_query: {
+      path: "/";
+      params: never;
+      query: Partial<Record<"key", 1 | 2 | 3>>;
+    };
+    mix_union_query: {
+      path: "/";
+      params: never;
+      query: Partial<Record<"key", "a" | 1 | true>>;
+    };
+  };
 
-	assertType<
-		IsExact<
-			ExtractRouteData<typeof flat_route_config>,
-			ExpectedExtractRouteData
-		>
-	>(true);
+  assertType<
+    IsExact<
+      ExtractRouteData<typeof flat_route_config>,
+      ExpectedExtractRouteData
+    >
+  >(true);
 });
 
 Deno.test("flatten_route_config", () => {
-	const expected_flat_route_config = {
-		string_param: "/:param<string>",
-		number_param: "/:param<number>",
-		boolean_param: "/:param<boolean>",
-		string_query: "/?key<string>",
-		number_query: "/?key<number>",
-		boolean_query: "/?key<boolean>",
-		strings_union_param: "/:param<(a|b|c)>",
-		numbers_union_param: "/:param<(1|2|3)>",
-		mix_union_param: "/:param<(a|1|true)>",
-		strings_union_query: "/?key<(a|b|c)>",
-		numbers_union_query: "/?key<(1|2|3)>",
-		mix_union_query: "/?key<(a|1|true)>",
-	} as const satisfies FlatRoutes<typeof route_config>;
+  const expected_flat_route_config = {
+    string_param: "/:param<string>",
+    number_param: "/:param<number>",
+    boolean_param: "/:param<boolean>",
+    string_query: "/?key<string>",
+    number_query: "/?key<number>",
+    boolean_query: "/?key<boolean>",
+    strings_union_param: "/:param<(a|b|c)>",
+    numbers_union_param: "/:param<(1|2|3)>",
+    mix_union_param: "/:param<(a|1|true)>",
+    strings_union_query: "/?key<(a|b|c)>",
+    numbers_union_query: "/?key<(1|2|3)>",
+    mix_union_query: "/?key<(a|1|true)>",
+  } as const satisfies FlatRoutes<typeof route_config>;
 
-	assertEquals(flat_route_config, expected_flat_route_config);
+  assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test(
-	"The constraint area should be removed when creating the path",
-	() => {
-		const link = create_link_generator(flat_route_config);
-		const path = link("string_param", { param: "a" });
-		assertEquals(path, "/a");
-	}
+  "The constraint area should be removed when creating the path",
+  () => {
+    const link = create_link_generator(flat_route_config);
+    const path = link("string_param", { param: "a" });
+    assertEquals(path, "/a");
+  },
 );

--- a/test/path_static.test.ts
+++ b/test/path_static.test.ts
@@ -1,96 +1,96 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-	create_link_generator,
-	type ExtractRouteData,
-	type FlatRoutes,
-	flatten_route_config,
-	type RouteConfig,
+  create_link_generator,
+  type ExtractRouteData,
+  type FlatRoutes,
+  flatten_route_config,
+  type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-	root: {
-		path: "/",
-	},
-	with_name: {
-		path: "/name",
-	},
-	nested: {
-		path: "/nested",
-		children: {
-			deep: {
-				path: "/deep",
-			},
-		},
-	},
+  root: {
+    path: "/",
+  },
+  with_name: {
+    path: "/name",
+  },
+  nested: {
+    path: "/nested",
+    children: {
+      deep: {
+        path: "/deep",
+      },
+    },
+  },
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-	type ExpectedFlatRoutes = {
-		root: "/";
-		with_name: "/name";
-		nested: "/nested";
-		"nested/deep": "/nested/deep";
-	};
+  type ExpectedFlatRoutes = {
+    root: "/";
+    with_name: "/name";
+    nested: "/nested";
+    "nested/deep": "/nested/deep";
+  };
 
-	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-		true
-	);
+  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+    true,
+  );
 });
 
 Deno.test("ExtractRouteData type", () => {
-	type ExpectedExtractRouteData = {
-		root: {
-			path: "/";
-			params: never;
-			query: never;
-		};
-		with_name: {
-			path: "/name";
-			params: never;
-			query: never;
-		};
-		nested: {
-			path: "/nested";
-			params: never;
-			query: never;
-		};
-		"nested/deep": {
-			path: "/nested/deep";
-			params: never;
-			query: never;
-		};
-	};
-	assertType<
-		IsExact<
-			ExtractRouteData<typeof flat_route_config>,
-			ExpectedExtractRouteData
-		>
-	>(true);
+  type ExpectedExtractRouteData = {
+    root: {
+      path: "/";
+      params: never;
+      query: never;
+    };
+    with_name: {
+      path: "/name";
+      params: never;
+      query: never;
+    };
+    nested: {
+      path: "/nested";
+      params: never;
+      query: never;
+    };
+    "nested/deep": {
+      path: "/nested/deep";
+      params: never;
+      query: never;
+    };
+  };
+  assertType<
+    IsExact<
+      ExtractRouteData<typeof flat_route_config>,
+      ExpectedExtractRouteData
+    >
+  >(true);
 });
 
 Deno.test("flatten_route_config", () => {
-	const expected_flat_route_config = {
-		root: "/",
-		with_name: "/name",
-		nested: "/nested",
-		"nested/deep": "/nested/deep",
-	} as const satisfies FlatRoutes<typeof route_config>;
+  const expected_flat_route_config = {
+    root: "/",
+    with_name: "/name",
+    nested: "/nested",
+    "nested/deep": "/nested/deep",
+  } as const satisfies FlatRoutes<typeof route_config>;
 
-	assertEquals(flat_route_config, expected_flat_route_config);
+  assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", () => {
-	const link = create_link_generator(flat_route_config);
-	const path_to_root = link("root");
-	const path_to_with_name = link("with_name");
-	const path_to_nested = link("nested");
-	const path_to_nested_deep = link("nested/deep");
+  const link = create_link_generator(flat_route_config);
+  const path_to_root = link("root");
+  const path_to_with_name = link("with_name");
+  const path_to_nested = link("nested");
+  const path_to_nested_deep = link("nested/deep");
 
-	assertEquals(path_to_root, "/");
-	assertEquals(path_to_with_name, "/name");
-	assertEquals(path_to_nested, "/nested");
-	assertEquals(path_to_nested_deep, "/nested/deep");
+  assertEquals(path_to_root, "/");
+  assertEquals(path_to_with_name, "/name");
+  assertEquals(path_to_nested, "/nested");
+  assertEquals(path_to_nested_deep, "/nested/deep");
 });

--- a/test/path_static.test.ts
+++ b/test/path_static.test.ts
@@ -1,96 +1,96 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-  create_link_generator,
-  type ExtractRouteData,
-  type FlatRoutes,
-  flatten_route_config,
-  type RouteConfig,
+	create_link_generator,
+	type ExtractRouteData,
+	type FlatRoutes,
+	flatten_route_config,
+	type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-  root: {
-    path: "/",
-  },
-  with_name: {
-    path: "/name",
-  },
-  nested: {
-    path: "/nested",
-    children: {
-      deep: {
-        path: "/deep",
-      },
-    },
-  },
+	root: {
+		path: "/",
+	},
+	with_name: {
+		path: "/name",
+	},
+	nested: {
+		path: "/nested",
+		children: {
+			deep: {
+				path: "/deep",
+			},
+		},
+	},
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-  type ExpectedFlatRoutes = {
-    root: "/";
-    with_name: "/name";
-    nested: "/nested";
-    "nested/deep": "/nested/deep";
-  };
+	type ExpectedFlatRoutes = {
+		root: "/";
+		with_name: "/name";
+		nested: "/nested";
+		"nested/deep": "/nested/deep";
+	};
 
-  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-    true,
-  );
+	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+		true
+	);
 });
 
 Deno.test("ExtractRouteData type", () => {
-  type ExpectedExtractRouteData = {
-    root: {
-      path: "/";
-      params: never;
-      queries: never;
-    };
-    with_name: {
-      path: "/name";
-      params: never;
-      queries: never;
-    };
-    nested: {
-      path: "/nested";
-      params: never;
-      queries: never;
-    };
-    "nested/deep": {
-      path: "/nested/deep";
-      params: never;
-      queries: never;
-    };
-  };
-  assertType<
-    IsExact<
-      ExtractRouteData<typeof flat_route_config>,
-      ExpectedExtractRouteData
-    >
-  >(true);
+	type ExpectedExtractRouteData = {
+		root: {
+			path: "/";
+			params: never;
+			query: never;
+		};
+		with_name: {
+			path: "/name";
+			params: never;
+			query: never;
+		};
+		nested: {
+			path: "/nested";
+			params: never;
+			query: never;
+		};
+		"nested/deep": {
+			path: "/nested/deep";
+			params: never;
+			query: never;
+		};
+	};
+	assertType<
+		IsExact<
+			ExtractRouteData<typeof flat_route_config>,
+			ExpectedExtractRouteData
+		>
+	>(true);
 });
 
 Deno.test("flatten_route_config", () => {
-  const expected_flat_route_config = {
-    root: "/",
-    with_name: "/name",
-    nested: "/nested",
-    "nested/deep": "/nested/deep",
-  } as const satisfies FlatRoutes<typeof route_config>;
+	const expected_flat_route_config = {
+		root: "/",
+		with_name: "/name",
+		nested: "/nested",
+		"nested/deep": "/nested/deep",
+	} as const satisfies FlatRoutes<typeof route_config>;
 
-  assertEquals(flat_route_config, expected_flat_route_config);
+	assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", () => {
-  const link = create_link_generator(flat_route_config);
-  const path_to_root = link("root");
-  const path_to_with_name = link("with_name");
-  const path_to_nested = link("nested");
-  const path_to_nested_deep = link("nested/deep");
+	const link = create_link_generator(flat_route_config);
+	const path_to_root = link("root");
+	const path_to_with_name = link("with_name");
+	const path_to_nested = link("nested");
+	const path_to_nested_deep = link("nested/deep");
 
-  assertEquals(path_to_root, "/");
-  assertEquals(path_to_with_name, "/name");
-  assertEquals(path_to_nested, "/nested");
-  assertEquals(path_to_nested_deep, "/nested/deep");
+	assertEquals(path_to_root, "/");
+	assertEquals(path_to_with_name, "/name");
+	assertEquals(path_to_nested, "/nested");
+	assertEquals(path_to_nested_deep, "/nested/deep");
 });

--- a/test/path_with_params.test.ts
+++ b/test/path_with_params.test.ts
@@ -1,184 +1,183 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-  create_link_generator,
-  type DefaultParamValue,
-  type ExtractRouteData,
-  type FlatRoutes,
-  flatten_route_config,
-  type RouteConfig,
+	create_link_generator,
+	type DefaultParamValue,
+	type ExtractRouteData,
+	type FlatRoutes,
+	flatten_route_config,
+	type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-  root: {
-    path: "/:param",
-  },
-  with_name: {
-    path: "/name/:param",
-  },
-  nested: {
-    path: "/nested",
-    children: {
-      deep: {
-        path: "/deep/:param",
-      },
-    },
-  },
-  nested_with_parent_param: {
-    path: "/nested/:parent-param",
-    children: {
-      deep: {
-        path: "/deep/:child-param",
-      },
-    },
-  },
+	root: {
+		path: "/:param",
+	},
+	with_name: {
+		path: "/name/:param",
+	},
+	nested: {
+		path: "/nested",
+		children: {
+			deep: {
+				path: "/deep/:param",
+			},
+		},
+	},
+	nested_with_parent_param: {
+		path: "/nested/:parent-param",
+		children: {
+			deep: {
+				path: "/deep/:child-param",
+			},
+		},
+	},
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-  type ExpectedFlatRoutes = {
-    root: "/:param";
-    with_name: "/name/:param";
-    nested: "/nested";
-    "nested/deep": "/nested/deep/:param";
-    nested_with_parent_param: "/nested/:parent-param";
-    "nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param";
-  };
+	type ExpectedFlatRoutes = {
+		root: "/:param";
+		with_name: "/name/:param";
+		nested: "/nested";
+		"nested/deep": "/nested/deep/:param";
+		nested_with_parent_param: "/nested/:parent-param";
+		"nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param";
+	};
 
-  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-    true,
-  );
+	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+		true
+	);
 });
 
 Deno.test("ExtractRouteData type", () => {
-  type ExpectedExtractRouteData = {
-    root: {
-      path: "/:param";
-      params: Record<"param", DefaultParamValue>;
-      queries: never;
-    };
-    with_name: {
-      path: "/name/:param";
-      params: Record<"param", DefaultParamValue>;
-      queries: never;
-    };
-    nested: {
-      path: "/nested";
-      params: never;
-      queries: never;
-    };
-    "nested/deep": {
-      path: "/nested/deep/:param";
-      params: Record<"param", DefaultParamValue>;
-      queries: never;
-    };
-    nested_with_parent_param: {
-      path: "/nested/:parent-param";
-      params: Record<"parent-param", DefaultParamValue>;
-      queries: never;
-    };
+	type ExpectedExtractRouteData = {
+		root: {
+			path: "/:param";
+			params: Record<"param", DefaultParamValue>;
+			query: never;
+		};
+		with_name: {
+			path: "/name/:param";
+			params: Record<"param", DefaultParamValue>;
+			query: never;
+		};
+		nested: {
+			path: "/nested";
+			params: never;
+			query: never;
+		};
+		"nested/deep": {
+			path: "/nested/deep/:param";
+			params: Record<"param", DefaultParamValue>;
+			query: never;
+		};
+		nested_with_parent_param: {
+			path: "/nested/:parent-param";
+			params: Record<"parent-param", DefaultParamValue>;
+			query: never;
+		};
 
-    "nested_with_parent_param/deep": {
-      path: "/nested/:parent-param/deep/:child-param";
-      params:
-        & Record<"child-param", DefaultParamValue>
-        & Record<"parent-param", DefaultParamValue>;
-      queries: never;
-    };
-  };
+		"nested_with_parent_param/deep": {
+			path: "/nested/:parent-param/deep/:child-param";
+			params: Record<"child-param", DefaultParamValue> &
+				Record<"parent-param", DefaultParamValue>;
+			query: never;
+		};
+	};
 
-  type A = Pick<ExtractRouteData<typeof flat_route_config>, "nested/deep">;
+	type A = Pick<ExtractRouteData<typeof flat_route_config>, "nested/deep">;
 
-  assertType<
-    IsExact<
-      ExtractRouteData<typeof flat_route_config>,
-      ExpectedExtractRouteData
-    >
-  >(true);
+	assertType<
+		IsExact<
+			ExtractRouteData<typeof flat_route_config>,
+			ExpectedExtractRouteData
+		>
+	>(true);
 });
 
 Deno.test("flatten_route_config", () => {
-  const expected_flat_route_config = {
-    root: "/:param",
-    with_name: "/name/:param",
-    nested: "/nested",
-    "nested/deep": "/nested/deep/:param",
-    nested_with_parent_param: "/nested/:parent-param",
-    "nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param",
-  } as const satisfies FlatRoutes<typeof route_config>;
+	const expected_flat_route_config = {
+		root: "/:param",
+		with_name: "/name/:param",
+		nested: "/nested",
+		"nested/deep": "/nested/deep/:param",
+		nested_with_parent_param: "/nested/:parent-param",
+		"nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param",
+	} as const satisfies FlatRoutes<typeof route_config>;
 
-  assertEquals(flat_route_config, expected_flat_route_config);
+	assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", async (t) => {
-  const link = create_link_generator(flat_route_config);
+	const link = create_link_generator(flat_route_config);
 
-  await t.step("string param value", () => {
-    const path_to_root = link("root", { param: "a" });
-    const path_to_with_name = link("with_name", { param: "a" });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link("nested/deep", { param: "a" });
-    const path_to_nested_with_parent_param = link("nested_with_parent_param", {
-      "parent-param": "a",
-    });
-    const path_to_nested_deep__with_parent_param = link(
-      "nested_with_parent_param/deep",
-      { "parent-param": "a", "child-param": "b" },
-    );
+	await t.step("string param value", () => {
+		const path_to_root = link("root", { param: "a" });
+		const path_to_with_name = link("with_name", { param: "a" });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link("nested/deep", { param: "a" });
+		const path_to_nested_with_parent_param = link("nested_with_parent_param", {
+			"parent-param": "a",
+		});
+		const path_to_nested_deep__with_parent_param = link(
+			"nested_with_parent_param/deep",
+			{ "parent-param": "a", "child-param": "b" }
+		);
 
-    assertEquals(path_to_root, "/a");
-    assertEquals(path_to_with_name, "/name/a");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep/a");
-    assertEquals(path_to_nested_with_parent_param, "/nested/a");
-    assertEquals(path_to_nested_deep__with_parent_param, "/nested/a/deep/b");
-  });
+		assertEquals(path_to_root, "/a");
+		assertEquals(path_to_with_name, "/name/a");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep/a");
+		assertEquals(path_to_nested_with_parent_param, "/nested/a");
+		assertEquals(path_to_nested_deep__with_parent_param, "/nested/a/deep/b");
+	});
 
-  await t.step("number param value", () => {
-    const path_to_root = link("root", { param: 1 });
-    const path_to_with_name = link("with_name", { param: 1 });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link("nested/deep", { param: 1 });
-    const path_to_nested_with_parent_param = link("nested_with_parent_param", {
-      "parent-param": 1,
-    });
-    const path_to_nested_deep__with_parent_param = link(
-      "nested_with_parent_param/deep",
-      { "parent-param": 1, "child-param": 2 },
-    );
-    const path_to_root_with_falsy_param_value = link("root", { param: 0 });
+	await t.step("number param value", () => {
+		const path_to_root = link("root", { param: 1 });
+		const path_to_with_name = link("with_name", { param: 1 });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link("nested/deep", { param: 1 });
+		const path_to_nested_with_parent_param = link("nested_with_parent_param", {
+			"parent-param": 1,
+		});
+		const path_to_nested_deep__with_parent_param = link(
+			"nested_with_parent_param/deep",
+			{ "parent-param": 1, "child-param": 2 }
+		);
+		const path_to_root_with_falsy_param_value = link("root", { param: 0 });
 
-    assertEquals(path_to_root, "/1");
-    assertEquals(path_to_with_name, "/name/1");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep/1");
-    assertEquals(path_to_nested_with_parent_param, "/nested/1");
-    assertEquals(path_to_nested_deep__with_parent_param, "/nested/1/deep/2");
-    assertEquals(path_to_root_with_falsy_param_value, "/0");
-  });
+		assertEquals(path_to_root, "/1");
+		assertEquals(path_to_with_name, "/name/1");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep/1");
+		assertEquals(path_to_nested_with_parent_param, "/nested/1");
+		assertEquals(path_to_nested_deep__with_parent_param, "/nested/1/deep/2");
+		assertEquals(path_to_root_with_falsy_param_value, "/0");
+	});
 
-  await t.step("boolean param value", () => {
-    const path_to_root = link("root", { param: true });
-    const path_to_with_name = link("with_name", { param: true });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link("nested/deep", { param: true });
-    const path_to_nested_with_parent_param = link("nested_with_parent_param", {
-      "parent-param": true,
-    });
-    const path_to_nested_deep__with_parent_param = link(
-      "nested_with_parent_param/deep",
-      { "parent-param": true, "child-param": false },
-    );
+	await t.step("boolean param value", () => {
+		const path_to_root = link("root", { param: true });
+		const path_to_with_name = link("with_name", { param: true });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link("nested/deep", { param: true });
+		const path_to_nested_with_parent_param = link("nested_with_parent_param", {
+			"parent-param": true,
+		});
+		const path_to_nested_deep__with_parent_param = link(
+			"nested_with_parent_param/deep",
+			{ "parent-param": true, "child-param": false }
+		);
 
-    assertEquals(path_to_root, "/true");
-    assertEquals(path_to_with_name, "/name/true");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep/true");
-    assertEquals(path_to_nested_with_parent_param, "/nested/true");
-    assertEquals(
-      path_to_nested_deep__with_parent_param,
-      "/nested/true/deep/false",
-    );
-  });
+		assertEquals(path_to_root, "/true");
+		assertEquals(path_to_with_name, "/name/true");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep/true");
+		assertEquals(path_to_nested_with_parent_param, "/nested/true");
+		assertEquals(
+			path_to_nested_deep__with_parent_param,
+			"/nested/true/deep/false"
+		);
+	});
 });

--- a/test/path_with_params.test.ts
+++ b/test/path_with_params.test.ts
@@ -1,183 +1,184 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-	create_link_generator,
-	type DefaultParamValue,
-	type ExtractRouteData,
-	type FlatRoutes,
-	flatten_route_config,
-	type RouteConfig,
+  create_link_generator,
+  type DefaultParamValue,
+  type ExtractRouteData,
+  type FlatRoutes,
+  flatten_route_config,
+  type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-	root: {
-		path: "/:param",
-	},
-	with_name: {
-		path: "/name/:param",
-	},
-	nested: {
-		path: "/nested",
-		children: {
-			deep: {
-				path: "/deep/:param",
-			},
-		},
-	},
-	nested_with_parent_param: {
-		path: "/nested/:parent-param",
-		children: {
-			deep: {
-				path: "/deep/:child-param",
-			},
-		},
-	},
+  root: {
+    path: "/:param",
+  },
+  with_name: {
+    path: "/name/:param",
+  },
+  nested: {
+    path: "/nested",
+    children: {
+      deep: {
+        path: "/deep/:param",
+      },
+    },
+  },
+  nested_with_parent_param: {
+    path: "/nested/:parent-param",
+    children: {
+      deep: {
+        path: "/deep/:child-param",
+      },
+    },
+  },
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-	type ExpectedFlatRoutes = {
-		root: "/:param";
-		with_name: "/name/:param";
-		nested: "/nested";
-		"nested/deep": "/nested/deep/:param";
-		nested_with_parent_param: "/nested/:parent-param";
-		"nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param";
-	};
+  type ExpectedFlatRoutes = {
+    root: "/:param";
+    with_name: "/name/:param";
+    nested: "/nested";
+    "nested/deep": "/nested/deep/:param";
+    nested_with_parent_param: "/nested/:parent-param";
+    "nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param";
+  };
 
-	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-		true
-	);
+  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+    true,
+  );
 });
 
 Deno.test("ExtractRouteData type", () => {
-	type ExpectedExtractRouteData = {
-		root: {
-			path: "/:param";
-			params: Record<"param", DefaultParamValue>;
-			query: never;
-		};
-		with_name: {
-			path: "/name/:param";
-			params: Record<"param", DefaultParamValue>;
-			query: never;
-		};
-		nested: {
-			path: "/nested";
-			params: never;
-			query: never;
-		};
-		"nested/deep": {
-			path: "/nested/deep/:param";
-			params: Record<"param", DefaultParamValue>;
-			query: never;
-		};
-		nested_with_parent_param: {
-			path: "/nested/:parent-param";
-			params: Record<"parent-param", DefaultParamValue>;
-			query: never;
-		};
+  type ExpectedExtractRouteData = {
+    root: {
+      path: "/:param";
+      params: Record<"param", DefaultParamValue>;
+      query: never;
+    };
+    with_name: {
+      path: "/name/:param";
+      params: Record<"param", DefaultParamValue>;
+      query: never;
+    };
+    nested: {
+      path: "/nested";
+      params: never;
+      query: never;
+    };
+    "nested/deep": {
+      path: "/nested/deep/:param";
+      params: Record<"param", DefaultParamValue>;
+      query: never;
+    };
+    nested_with_parent_param: {
+      path: "/nested/:parent-param";
+      params: Record<"parent-param", DefaultParamValue>;
+      query: never;
+    };
 
-		"nested_with_parent_param/deep": {
-			path: "/nested/:parent-param/deep/:child-param";
-			params: Record<"child-param", DefaultParamValue> &
-				Record<"parent-param", DefaultParamValue>;
-			query: never;
-		};
-	};
+    "nested_with_parent_param/deep": {
+      path: "/nested/:parent-param/deep/:child-param";
+      params:
+        & Record<"child-param", DefaultParamValue>
+        & Record<"parent-param", DefaultParamValue>;
+      query: never;
+    };
+  };
 
-	type A = Pick<ExtractRouteData<typeof flat_route_config>, "nested/deep">;
+  type A = Pick<ExtractRouteData<typeof flat_route_config>, "nested/deep">;
 
-	assertType<
-		IsExact<
-			ExtractRouteData<typeof flat_route_config>,
-			ExpectedExtractRouteData
-		>
-	>(true);
+  assertType<
+    IsExact<
+      ExtractRouteData<typeof flat_route_config>,
+      ExpectedExtractRouteData
+    >
+  >(true);
 });
 
 Deno.test("flatten_route_config", () => {
-	const expected_flat_route_config = {
-		root: "/:param",
-		with_name: "/name/:param",
-		nested: "/nested",
-		"nested/deep": "/nested/deep/:param",
-		nested_with_parent_param: "/nested/:parent-param",
-		"nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param",
-	} as const satisfies FlatRoutes<typeof route_config>;
+  const expected_flat_route_config = {
+    root: "/:param",
+    with_name: "/name/:param",
+    nested: "/nested",
+    "nested/deep": "/nested/deep/:param",
+    nested_with_parent_param: "/nested/:parent-param",
+    "nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param",
+  } as const satisfies FlatRoutes<typeof route_config>;
 
-	assertEquals(flat_route_config, expected_flat_route_config);
+  assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", async (t) => {
-	const link = create_link_generator(flat_route_config);
+  const link = create_link_generator(flat_route_config);
 
-	await t.step("string param value", () => {
-		const path_to_root = link("root", { param: "a" });
-		const path_to_with_name = link("with_name", { param: "a" });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link("nested/deep", { param: "a" });
-		const path_to_nested_with_parent_param = link("nested_with_parent_param", {
-			"parent-param": "a",
-		});
-		const path_to_nested_deep__with_parent_param = link(
-			"nested_with_parent_param/deep",
-			{ "parent-param": "a", "child-param": "b" }
-		);
+  await t.step("string param value", () => {
+    const path_to_root = link("root", { param: "a" });
+    const path_to_with_name = link("with_name", { param: "a" });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link("nested/deep", { param: "a" });
+    const path_to_nested_with_parent_param = link("nested_with_parent_param", {
+      "parent-param": "a",
+    });
+    const path_to_nested_deep__with_parent_param = link(
+      "nested_with_parent_param/deep",
+      { "parent-param": "a", "child-param": "b" },
+    );
 
-		assertEquals(path_to_root, "/a");
-		assertEquals(path_to_with_name, "/name/a");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep/a");
-		assertEquals(path_to_nested_with_parent_param, "/nested/a");
-		assertEquals(path_to_nested_deep__with_parent_param, "/nested/a/deep/b");
-	});
+    assertEquals(path_to_root, "/a");
+    assertEquals(path_to_with_name, "/name/a");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep/a");
+    assertEquals(path_to_nested_with_parent_param, "/nested/a");
+    assertEquals(path_to_nested_deep__with_parent_param, "/nested/a/deep/b");
+  });
 
-	await t.step("number param value", () => {
-		const path_to_root = link("root", { param: 1 });
-		const path_to_with_name = link("with_name", { param: 1 });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link("nested/deep", { param: 1 });
-		const path_to_nested_with_parent_param = link("nested_with_parent_param", {
-			"parent-param": 1,
-		});
-		const path_to_nested_deep__with_parent_param = link(
-			"nested_with_parent_param/deep",
-			{ "parent-param": 1, "child-param": 2 }
-		);
-		const path_to_root_with_falsy_param_value = link("root", { param: 0 });
+  await t.step("number param value", () => {
+    const path_to_root = link("root", { param: 1 });
+    const path_to_with_name = link("with_name", { param: 1 });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link("nested/deep", { param: 1 });
+    const path_to_nested_with_parent_param = link("nested_with_parent_param", {
+      "parent-param": 1,
+    });
+    const path_to_nested_deep__with_parent_param = link(
+      "nested_with_parent_param/deep",
+      { "parent-param": 1, "child-param": 2 },
+    );
+    const path_to_root_with_falsy_param_value = link("root", { param: 0 });
 
-		assertEquals(path_to_root, "/1");
-		assertEquals(path_to_with_name, "/name/1");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep/1");
-		assertEquals(path_to_nested_with_parent_param, "/nested/1");
-		assertEquals(path_to_nested_deep__with_parent_param, "/nested/1/deep/2");
-		assertEquals(path_to_root_with_falsy_param_value, "/0");
-	});
+    assertEquals(path_to_root, "/1");
+    assertEquals(path_to_with_name, "/name/1");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep/1");
+    assertEquals(path_to_nested_with_parent_param, "/nested/1");
+    assertEquals(path_to_nested_deep__with_parent_param, "/nested/1/deep/2");
+    assertEquals(path_to_root_with_falsy_param_value, "/0");
+  });
 
-	await t.step("boolean param value", () => {
-		const path_to_root = link("root", { param: true });
-		const path_to_with_name = link("with_name", { param: true });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link("nested/deep", { param: true });
-		const path_to_nested_with_parent_param = link("nested_with_parent_param", {
-			"parent-param": true,
-		});
-		const path_to_nested_deep__with_parent_param = link(
-			"nested_with_parent_param/deep",
-			{ "parent-param": true, "child-param": false }
-		);
+  await t.step("boolean param value", () => {
+    const path_to_root = link("root", { param: true });
+    const path_to_with_name = link("with_name", { param: true });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link("nested/deep", { param: true });
+    const path_to_nested_with_parent_param = link("nested_with_parent_param", {
+      "parent-param": true,
+    });
+    const path_to_nested_deep__with_parent_param = link(
+      "nested_with_parent_param/deep",
+      { "parent-param": true, "child-param": false },
+    );
 
-		assertEquals(path_to_root, "/true");
-		assertEquals(path_to_with_name, "/name/true");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep/true");
-		assertEquals(path_to_nested_with_parent_param, "/nested/true");
-		assertEquals(
-			path_to_nested_deep__with_parent_param,
-			"/nested/true/deep/false"
-		);
-	});
+    assertEquals(path_to_root, "/true");
+    assertEquals(path_to_with_name, "/name/true");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep/true");
+    assertEquals(path_to_nested_with_parent_param, "/nested/true");
+    assertEquals(
+      path_to_nested_deep__with_parent_param,
+      "/nested/true/deep/false",
+    );
+  });
 });

--- a/test/path_with_params_and_query.test.ts
+++ b/test/path_with_params_and_query.test.ts
@@ -1,291 +1,293 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-	create_link_generator,
-	type DefaultParamValue,
-	type ExtractRouteData,
-	type FlatRoutes,
-	flatten_route_config,
-	type RouteConfig,
+  create_link_generator,
+  type DefaultParamValue,
+  type ExtractRouteData,
+  type FlatRoutes,
+  flatten_route_config,
+  type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-	root: {
-		path: "/:param?key",
-	},
-	with_name: {
-		path: "/name/:param?key",
-	},
-	nested: {
-		path: "/nested",
-		children: {
-			deep: {
-				path: "/deep/:child-param?key",
-			},
-		},
-	},
-	nested_with_parent_param: {
-		path: "/nested/:parent-param?parent-key",
-		children: {
-			deep: {
-				path: "/deep/:child-param?child-key",
-			},
-		},
-	},
+  root: {
+    path: "/:param?key",
+  },
+  with_name: {
+    path: "/name/:param?key",
+  },
+  nested: {
+    path: "/nested",
+    children: {
+      deep: {
+        path: "/deep/:child-param?key",
+      },
+    },
+  },
+  nested_with_parent_param: {
+    path: "/nested/:parent-param?parent-key",
+    children: {
+      deep: {
+        path: "/deep/:child-param?child-key",
+      },
+    },
+  },
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-	type ExpectedFlatRoutes = {
-		root: "/:param?key";
-		with_name: "/name/:param?key";
-		nested: "/nested";
-		"nested/deep": "/nested/deep/:child-param?key";
-		nested_with_parent_param: "/nested/:parent-param?parent-key";
-		"nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param?child-key";
-	};
+  type ExpectedFlatRoutes = {
+    root: "/:param?key";
+    with_name: "/name/:param?key";
+    nested: "/nested";
+    "nested/deep": "/nested/deep/:child-param?key";
+    nested_with_parent_param: "/nested/:parent-param?parent-key";
+    "nested_with_parent_param/deep":
+      "/nested/:parent-param/deep/:child-param?child-key";
+  };
 
-	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-		true
-	);
+  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+    true,
+  );
 });
 
 Deno.test("ExtractRouteData type", () => {
-	type ExpectedExtractRouteData = {
-		root: {
-			path: "/:param";
-			params: Record<"param", DefaultParamValue>;
-			query: Partial<Record<"key", DefaultParamValue>>;
-		};
-		with_name: {
-			path: "/name/:param";
-			params: Record<"param", DefaultParamValue>;
-			query: Partial<Record<"key", DefaultParamValue>>;
-		};
-		nested: {
-			path: "/nested";
-			params: never;
-			query: never;
-		};
-		"nested/deep": {
-			path: "/nested/deep/:child-param";
-			params: Record<"child-param", DefaultParamValue>;
-			query: Partial<Record<"key", DefaultParamValue>>;
-		};
-		nested_with_parent_param: {
-			path: "/nested/:parent-param";
-			params: Record<"parent-param", DefaultParamValue>;
-			query: Partial<Record<"parent-key", DefaultParamValue>>;
-		};
+  type ExpectedExtractRouteData = {
+    root: {
+      path: "/:param";
+      params: Record<"param", DefaultParamValue>;
+      query: Partial<Record<"key", DefaultParamValue>>;
+    };
+    with_name: {
+      path: "/name/:param";
+      params: Record<"param", DefaultParamValue>;
+      query: Partial<Record<"key", DefaultParamValue>>;
+    };
+    nested: {
+      path: "/nested";
+      params: never;
+      query: never;
+    };
+    "nested/deep": {
+      path: "/nested/deep/:child-param";
+      params: Record<"child-param", DefaultParamValue>;
+      query: Partial<Record<"key", DefaultParamValue>>;
+    };
+    nested_with_parent_param: {
+      path: "/nested/:parent-param";
+      params: Record<"parent-param", DefaultParamValue>;
+      query: Partial<Record<"parent-key", DefaultParamValue>>;
+    };
 
-		"nested_with_parent_param/deep": {
-			path: "/nested/:parent-param/deep/:child-param";
-			params: Record<"child-param", DefaultParamValue> &
-				Record<"parent-param", DefaultParamValue>;
-			query: Partial<Record<"child-key", DefaultParamValue>>;
-		};
-	};
+    "nested_with_parent_param/deep": {
+      path: "/nested/:parent-param/deep/:child-param";
+      params:
+        & Record<"child-param", DefaultParamValue>
+        & Record<"parent-param", DefaultParamValue>;
+      query: Partial<Record<"child-key", DefaultParamValue>>;
+    };
+  };
 
-	assertType<
-		IsExact<
-			ExtractRouteData<typeof flat_route_config>,
-			ExpectedExtractRouteData
-		>
-	>(true);
+  assertType<
+    IsExact<
+      ExtractRouteData<typeof flat_route_config>,
+      ExpectedExtractRouteData
+    >
+  >(true);
 });
 
 Deno.test("flatten_route_config", () => {
-	const expected_flat_route_config = {
-		root: "/:param?key",
-		with_name: "/name/:param?key",
-		nested: "/nested",
-		"nested/deep": "/nested/deep/:child-param?key",
-		nested_with_parent_param: "/nested/:parent-param?parent-key",
-		"nested_with_parent_param/deep":
-			"/nested/:parent-param/deep/:child-param?child-key",
-	} as const satisfies FlatRoutes<typeof route_config>;
+  const expected_flat_route_config = {
+    root: "/:param?key",
+    with_name: "/name/:param?key",
+    nested: "/nested",
+    "nested/deep": "/nested/deep/:child-param?key",
+    nested_with_parent_param: "/nested/:parent-param?parent-key",
+    "nested_with_parent_param/deep":
+      "/nested/:parent-param/deep/:child-param?child-key",
+  } as const satisfies FlatRoutes<typeof route_config>;
 
-	assertEquals(flat_route_config, expected_flat_route_config);
+  assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", async (t) => {
-	const link = create_link_generator(flat_route_config);
+  const link = create_link_generator(flat_route_config);
 
-	await t.step("string params and query", () => {
-		const path_to_root = link("root", { param: "a" }, { key: "b" });
-		const path_to_with_name = link("with_name", { param: "a" }, { key: "b" });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link(
-			"nested/deep",
-			{ "child-param": "a" },
-			{ key: "b" }
-		);
-		const path_to_nested_with_parent_param = link(
-			"nested_with_parent_param",
-			{
-				"parent-param": "a",
-			},
-			{ "parent-key": "b" }
-		);
-		const path_to_nested_deep__with_parent_param = link(
-			"nested_with_parent_param/deep",
-			{ "parent-param": "a", "child-param": "b" },
-			{ "child-key": "c" }
-		);
+  await t.step("string params and query", () => {
+    const path_to_root = link("root", { param: "a" }, { key: "b" });
+    const path_to_with_name = link("with_name", { param: "a" }, { key: "b" });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link(
+      "nested/deep",
+      { "child-param": "a" },
+      { key: "b" },
+    );
+    const path_to_nested_with_parent_param = link(
+      "nested_with_parent_param",
+      {
+        "parent-param": "a",
+      },
+      { "parent-key": "b" },
+    );
+    const path_to_nested_deep__with_parent_param = link(
+      "nested_with_parent_param/deep",
+      { "parent-param": "a", "child-param": "b" },
+      { "child-key": "c" },
+    );
 
-		assertEquals(path_to_root, "/a?key=b");
-		assertEquals(path_to_with_name, "/name/a?key=b");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep/a?key=b");
-		assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=b");
-		assertEquals(
-			path_to_nested_deep__with_parent_param,
-			"/nested/a/deep/b?child-key=c"
-		);
-	});
+    assertEquals(path_to_root, "/a?key=b");
+    assertEquals(path_to_with_name, "/name/a?key=b");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep/a?key=b");
+    assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=b");
+    assertEquals(
+      path_to_nested_deep__with_parent_param,
+      "/nested/a/deep/b?child-key=c",
+    );
+  });
 
-	await t.step("number params and string query", () => {
-		const path_to_root = link("root", { param: 1 }, { key: "a" });
-		const path_to_with_name = link("with_name", { param: 1 }, { key: "a" });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link(
-			"nested/deep",
-			{ "child-param": 1 },
-			{ key: "a" }
-		);
-		const path_to_nested_with_parent_param = link(
-			"nested_with_parent_param",
-			{
-				"parent-param": 1,
-			},
-			{ "parent-key": "a" }
-		);
-		const path_to_nested_deep__with_parent_param = link(
-			"nested_with_parent_param/deep",
-			{ "parent-param": 1, "child-param": 2 },
-			{ "child-key": "a" }
-		);
-		const path_to_root_with_falsy_param_value = link(
-			"root",
-			{ param: 0 },
-			{ key: "a" }
-		);
+  await t.step("number params and string query", () => {
+    const path_to_root = link("root", { param: 1 }, { key: "a" });
+    const path_to_with_name = link("with_name", { param: 1 }, { key: "a" });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link(
+      "nested/deep",
+      { "child-param": 1 },
+      { key: "a" },
+    );
+    const path_to_nested_with_parent_param = link(
+      "nested_with_parent_param",
+      {
+        "parent-param": 1,
+      },
+      { "parent-key": "a" },
+    );
+    const path_to_nested_deep__with_parent_param = link(
+      "nested_with_parent_param/deep",
+      { "parent-param": 1, "child-param": 2 },
+      { "child-key": "a" },
+    );
+    const path_to_root_with_falsy_param_value = link(
+      "root",
+      { param: 0 },
+      { key: "a" },
+    );
 
-		assertEquals(path_to_root, "/1?key=a");
-		assertEquals(path_to_with_name, "/name/1?key=a");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep/1?key=a");
-		assertEquals(path_to_nested_with_parent_param, "/nested/1?parent-key=a");
-		assertEquals(
-			path_to_nested_deep__with_parent_param,
-			"/nested/1/deep/2?child-key=a"
-		);
-		assertEquals(path_to_root_with_falsy_param_value, "/0?key=a");
-	});
+    assertEquals(path_to_root, "/1?key=a");
+    assertEquals(path_to_with_name, "/name/1?key=a");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep/1?key=a");
+    assertEquals(path_to_nested_with_parent_param, "/nested/1?parent-key=a");
+    assertEquals(
+      path_to_nested_deep__with_parent_param,
+      "/nested/1/deep/2?child-key=a",
+    );
+    assertEquals(path_to_root_with_falsy_param_value, "/0?key=a");
+  });
 
-	await t.step("boolean params and string query", () => {
-		const path_to_root = link("root", { param: true }, { key: "a" });
-		const path_to_with_name = link("with_name", { param: true }, { key: "a" });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link(
-			"nested/deep",
-			{ "child-param": true },
-			{ key: "a" }
-		);
-		const path_to_nested_with_parent_param = link(
-			"nested_with_parent_param",
-			{ "parent-param": true },
-			{ "parent-key": "a" }
-		);
-		const path_to_nested_deep_with_parent_param = link(
-			"nested_with_parent_param/deep",
-			{ "parent-param": true, "child-param": false },
-			{ "child-key": "a" }
-		);
+  await t.step("boolean params and string query", () => {
+    const path_to_root = link("root", { param: true }, { key: "a" });
+    const path_to_with_name = link("with_name", { param: true }, { key: "a" });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link(
+      "nested/deep",
+      { "child-param": true },
+      { key: "a" },
+    );
+    const path_to_nested_with_parent_param = link(
+      "nested_with_parent_param",
+      { "parent-param": true },
+      { "parent-key": "a" },
+    );
+    const path_to_nested_deep_with_parent_param = link(
+      "nested_with_parent_param/deep",
+      { "parent-param": true, "child-param": false },
+      { "child-key": "a" },
+    );
 
-		assertEquals(path_to_root, "/true?key=a");
-		assertEquals(path_to_with_name, "/name/true?key=a");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep/true?key=a");
-		assertEquals(path_to_nested_with_parent_param, "/nested/true?parent-key=a");
-		assertEquals(
-			path_to_nested_deep_with_parent_param,
-			"/nested/true/deep/false?child-key=a"
-		);
-	});
+    assertEquals(path_to_root, "/true?key=a");
+    assertEquals(path_to_with_name, "/name/true?key=a");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep/true?key=a");
+    assertEquals(path_to_nested_with_parent_param, "/nested/true?parent-key=a");
+    assertEquals(
+      path_to_nested_deep_with_parent_param,
+      "/nested/true/deep/false?child-key=a",
+    );
+  });
 
-	await t.step("string params and number query", () => {
-		const path_to_root = link("root", { param: "a" }, { key: 1 });
-		const path_to_with_name = link("with_name", { param: "a" }, { key: 1 });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link(
-			"nested/deep",
-			{ "child-param": "a" },
-			{ key: 1 }
-		);
-		const path_to_nested_with_parent_param = link(
-			"nested_with_parent_param",
-			{ "parent-param": "a" },
-			{ "parent-key": 1 }
-		);
-		const path_to_nested_deep_with_parent_param = link(
-			"nested_with_parent_param/deep",
-			{ "parent-param": "a", "child-param": "b" },
-			{ "child-key": 1 }
-		);
-		const path_to_root_with_falsy_query_value = link(
-			"root",
-			{ param: "a" },
-			{ key: 0 }
-		);
+  await t.step("string params and number query", () => {
+    const path_to_root = link("root", { param: "a" }, { key: 1 });
+    const path_to_with_name = link("with_name", { param: "a" }, { key: 1 });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link(
+      "nested/deep",
+      { "child-param": "a" },
+      { key: 1 },
+    );
+    const path_to_nested_with_parent_param = link(
+      "nested_with_parent_param",
+      { "parent-param": "a" },
+      { "parent-key": 1 },
+    );
+    const path_to_nested_deep_with_parent_param = link(
+      "nested_with_parent_param/deep",
+      { "parent-param": "a", "child-param": "b" },
+      { "child-key": 1 },
+    );
+    const path_to_root_with_falsy_query_value = link(
+      "root",
+      { param: "a" },
+      { key: 0 },
+    );
 
-		assertEquals(path_to_root, "/a?key=1");
-		assertEquals(path_to_with_name, "/name/a?key=1");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep/a?key=1");
-		assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=1");
-		assertEquals(
-			path_to_nested_deep_with_parent_param,
-			"/nested/a/deep/b?child-key=1"
-		);
-		assertEquals(path_to_root_with_falsy_query_value, "/a?key=0");
-	});
+    assertEquals(path_to_root, "/a?key=1");
+    assertEquals(path_to_with_name, "/name/a?key=1");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep/a?key=1");
+    assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=1");
+    assertEquals(
+      path_to_nested_deep_with_parent_param,
+      "/nested/a/deep/b?child-key=1",
+    );
+    assertEquals(path_to_root_with_falsy_query_value, "/a?key=0");
+  });
 
-	await t.step("string params and boolean query", () => {
-		const path_to_root = link("root", { param: "a" }, { key: true });
-		const path_to_with_name = link("with_name", { param: "a" }, { key: true });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link(
-			"nested/deep",
-			{ "child-param": "a" },
-			{ key: true }
-		);
-		const path_to_nested_with_parent_param = link(
-			"nested_with_parent_param",
-			{ "parent-param": "a" },
-			{ "parent-key": true }
-		);
-		const path_to_nested_deep_with_parent_param = link(
-			"nested_with_parent_param/deep",
-			{ "parent-param": "a", "child-param": "b" },
-			{ "child-key": true }
-		);
-		const path_to_root_with_falsy_query_value = link(
-			"root",
-			{ param: "a" },
-			{ key: false }
-		);
+  await t.step("string params and boolean query", () => {
+    const path_to_root = link("root", { param: "a" }, { key: true });
+    const path_to_with_name = link("with_name", { param: "a" }, { key: true });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link(
+      "nested/deep",
+      { "child-param": "a" },
+      { key: true },
+    );
+    const path_to_nested_with_parent_param = link(
+      "nested_with_parent_param",
+      { "parent-param": "a" },
+      { "parent-key": true },
+    );
+    const path_to_nested_deep_with_parent_param = link(
+      "nested_with_parent_param/deep",
+      { "parent-param": "a", "child-param": "b" },
+      { "child-key": true },
+    );
+    const path_to_root_with_falsy_query_value = link(
+      "root",
+      { param: "a" },
+      { key: false },
+    );
 
-		assertEquals(path_to_root, "/a?key=true");
-		assertEquals(path_to_with_name, "/name/a?key=true");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep/a?key=true");
-		assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=true");
-		assertEquals(
-			path_to_nested_deep_with_parent_param,
-			"/nested/a/deep/b?child-key=true"
-		);
-		assertEquals(path_to_root_with_falsy_query_value, "/a?key=false");
-	});
+    assertEquals(path_to_root, "/a?key=true");
+    assertEquals(path_to_with_name, "/name/a?key=true");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep/a?key=true");
+    assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=true");
+    assertEquals(
+      path_to_nested_deep_with_parent_param,
+      "/nested/a/deep/b?child-key=true",
+    );
+    assertEquals(path_to_root_with_falsy_query_value, "/a?key=false");
+  });
 });

--- a/test/path_with_params_and_query.test.ts
+++ b/test/path_with_params_and_query.test.ts
@@ -1,293 +1,291 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-  create_link_generator,
-  type DefaultParamValue,
-  type ExtractRouteData,
-  type FlatRoutes,
-  flatten_route_config,
-  type RouteConfig,
+	create_link_generator,
+	type DefaultParamValue,
+	type ExtractRouteData,
+	type FlatRoutes,
+	flatten_route_config,
+	type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-  root: {
-    path: "/:param?key",
-  },
-  with_name: {
-    path: "/name/:param?key",
-  },
-  nested: {
-    path: "/nested",
-    children: {
-      deep: {
-        path: "/deep/:child-param?key",
-      },
-    },
-  },
-  nested_with_parent_param: {
-    path: "/nested/:parent-param?parent-key",
-    children: {
-      deep: {
-        path: "/deep/:child-param?child-key",
-      },
-    },
-  },
+	root: {
+		path: "/:param?key",
+	},
+	with_name: {
+		path: "/name/:param?key",
+	},
+	nested: {
+		path: "/nested",
+		children: {
+			deep: {
+				path: "/deep/:child-param?key",
+			},
+		},
+	},
+	nested_with_parent_param: {
+		path: "/nested/:parent-param?parent-key",
+		children: {
+			deep: {
+				path: "/deep/:child-param?child-key",
+			},
+		},
+	},
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-  type ExpectedFlatRoutes = {
-    root: "/:param?key";
-    with_name: "/name/:param?key";
-    nested: "/nested";
-    "nested/deep": "/nested/deep/:child-param?key";
-    nested_with_parent_param: "/nested/:parent-param?parent-key";
-    "nested_with_parent_param/deep":
-      "/nested/:parent-param/deep/:child-param?child-key";
-  };
+	type ExpectedFlatRoutes = {
+		root: "/:param?key";
+		with_name: "/name/:param?key";
+		nested: "/nested";
+		"nested/deep": "/nested/deep/:child-param?key";
+		nested_with_parent_param: "/nested/:parent-param?parent-key";
+		"nested_with_parent_param/deep": "/nested/:parent-param/deep/:child-param?child-key";
+	};
 
-  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-    true,
-  );
+	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+		true
+	);
 });
 
 Deno.test("ExtractRouteData type", () => {
-  type ExpectedExtractRouteData = {
-    root: {
-      path: "/:param";
-      params: Record<"param", DefaultParamValue>;
-      queries: Partial<Record<"key", DefaultParamValue>>;
-    };
-    with_name: {
-      path: "/name/:param";
-      params: Record<"param", DefaultParamValue>;
-      queries: Partial<Record<"key", DefaultParamValue>>;
-    };
-    nested: {
-      path: "/nested";
-      params: never;
-      queries: never;
-    };
-    "nested/deep": {
-      path: "/nested/deep/:child-param";
-      params: Record<"child-param", DefaultParamValue>;
-      queries: Partial<Record<"key", DefaultParamValue>>;
-    };
-    nested_with_parent_param: {
-      path: "/nested/:parent-param";
-      params: Record<"parent-param", DefaultParamValue>;
-      queries: Partial<Record<"parent-key", DefaultParamValue>>;
-    };
+	type ExpectedExtractRouteData = {
+		root: {
+			path: "/:param";
+			params: Record<"param", DefaultParamValue>;
+			query: Partial<Record<"key", DefaultParamValue>>;
+		};
+		with_name: {
+			path: "/name/:param";
+			params: Record<"param", DefaultParamValue>;
+			query: Partial<Record<"key", DefaultParamValue>>;
+		};
+		nested: {
+			path: "/nested";
+			params: never;
+			query: never;
+		};
+		"nested/deep": {
+			path: "/nested/deep/:child-param";
+			params: Record<"child-param", DefaultParamValue>;
+			query: Partial<Record<"key", DefaultParamValue>>;
+		};
+		nested_with_parent_param: {
+			path: "/nested/:parent-param";
+			params: Record<"parent-param", DefaultParamValue>;
+			query: Partial<Record<"parent-key", DefaultParamValue>>;
+		};
 
-    "nested_with_parent_param/deep": {
-      path: "/nested/:parent-param/deep/:child-param";
-      params:
-        & Record<"child-param", DefaultParamValue>
-        & Record<"parent-param", DefaultParamValue>;
-      queries: Partial<Record<"child-key", DefaultParamValue>>;
-    };
-  };
+		"nested_with_parent_param/deep": {
+			path: "/nested/:parent-param/deep/:child-param";
+			params: Record<"child-param", DefaultParamValue> &
+				Record<"parent-param", DefaultParamValue>;
+			query: Partial<Record<"child-key", DefaultParamValue>>;
+		};
+	};
 
-  assertType<
-    IsExact<
-      ExtractRouteData<typeof flat_route_config>,
-      ExpectedExtractRouteData
-    >
-  >(true);
+	assertType<
+		IsExact<
+			ExtractRouteData<typeof flat_route_config>,
+			ExpectedExtractRouteData
+		>
+	>(true);
 });
 
 Deno.test("flatten_route_config", () => {
-  const expected_flat_route_config = {
-    root: "/:param?key",
-    with_name: "/name/:param?key",
-    nested: "/nested",
-    "nested/deep": "/nested/deep/:child-param?key",
-    nested_with_parent_param: "/nested/:parent-param?parent-key",
-    "nested_with_parent_param/deep":
-      "/nested/:parent-param/deep/:child-param?child-key",
-  } as const satisfies FlatRoutes<typeof route_config>;
+	const expected_flat_route_config = {
+		root: "/:param?key",
+		with_name: "/name/:param?key",
+		nested: "/nested",
+		"nested/deep": "/nested/deep/:child-param?key",
+		nested_with_parent_param: "/nested/:parent-param?parent-key",
+		"nested_with_parent_param/deep":
+			"/nested/:parent-param/deep/:child-param?child-key",
+	} as const satisfies FlatRoutes<typeof route_config>;
 
-  assertEquals(flat_route_config, expected_flat_route_config);
+	assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", async (t) => {
-  const link = create_link_generator(flat_route_config);
+	const link = create_link_generator(flat_route_config);
 
-  await t.step("string params and query", () => {
-    const path_to_root = link("root", { param: "a" }, { key: "b" });
-    const path_to_with_name = link("with_name", { param: "a" }, { key: "b" });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link(
-      "nested/deep",
-      { "child-param": "a" },
-      { key: "b" },
-    );
-    const path_to_nested_with_parent_param = link(
-      "nested_with_parent_param",
-      {
-        "parent-param": "a",
-      },
-      { "parent-key": "b" },
-    );
-    const path_to_nested_deep__with_parent_param = link(
-      "nested_with_parent_param/deep",
-      { "parent-param": "a", "child-param": "b" },
-      { "child-key": "c" },
-    );
+	await t.step("string params and query", () => {
+		const path_to_root = link("root", { param: "a" }, { key: "b" });
+		const path_to_with_name = link("with_name", { param: "a" }, { key: "b" });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link(
+			"nested/deep",
+			{ "child-param": "a" },
+			{ key: "b" }
+		);
+		const path_to_nested_with_parent_param = link(
+			"nested_with_parent_param",
+			{
+				"parent-param": "a",
+			},
+			{ "parent-key": "b" }
+		);
+		const path_to_nested_deep__with_parent_param = link(
+			"nested_with_parent_param/deep",
+			{ "parent-param": "a", "child-param": "b" },
+			{ "child-key": "c" }
+		);
 
-    assertEquals(path_to_root, "/a?key=b");
-    assertEquals(path_to_with_name, "/name/a?key=b");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep/a?key=b");
-    assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=b");
-    assertEquals(
-      path_to_nested_deep__with_parent_param,
-      "/nested/a/deep/b?child-key=c",
-    );
-  });
+		assertEquals(path_to_root, "/a?key=b");
+		assertEquals(path_to_with_name, "/name/a?key=b");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep/a?key=b");
+		assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=b");
+		assertEquals(
+			path_to_nested_deep__with_parent_param,
+			"/nested/a/deep/b?child-key=c"
+		);
+	});
 
-  await t.step("number params and string query", () => {
-    const path_to_root = link("root", { param: 1 }, { key: "a" });
-    const path_to_with_name = link("with_name", { param: 1 }, { key: "a" });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link(
-      "nested/deep",
-      { "child-param": 1 },
-      { key: "a" },
-    );
-    const path_to_nested_with_parent_param = link(
-      "nested_with_parent_param",
-      {
-        "parent-param": 1,
-      },
-      { "parent-key": "a" },
-    );
-    const path_to_nested_deep__with_parent_param = link(
-      "nested_with_parent_param/deep",
-      { "parent-param": 1, "child-param": 2 },
-      { "child-key": "a" },
-    );
-    const path_to_root_with_falsy_param_value = link(
-      "root",
-      { param: 0 },
-      { key: "a" },
-    );
+	await t.step("number params and string query", () => {
+		const path_to_root = link("root", { param: 1 }, { key: "a" });
+		const path_to_with_name = link("with_name", { param: 1 }, { key: "a" });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link(
+			"nested/deep",
+			{ "child-param": 1 },
+			{ key: "a" }
+		);
+		const path_to_nested_with_parent_param = link(
+			"nested_with_parent_param",
+			{
+				"parent-param": 1,
+			},
+			{ "parent-key": "a" }
+		);
+		const path_to_nested_deep__with_parent_param = link(
+			"nested_with_parent_param/deep",
+			{ "parent-param": 1, "child-param": 2 },
+			{ "child-key": "a" }
+		);
+		const path_to_root_with_falsy_param_value = link(
+			"root",
+			{ param: 0 },
+			{ key: "a" }
+		);
 
-    assertEquals(path_to_root, "/1?key=a");
-    assertEquals(path_to_with_name, "/name/1?key=a");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep/1?key=a");
-    assertEquals(path_to_nested_with_parent_param, "/nested/1?parent-key=a");
-    assertEquals(
-      path_to_nested_deep__with_parent_param,
-      "/nested/1/deep/2?child-key=a",
-    );
-    assertEquals(path_to_root_with_falsy_param_value, "/0?key=a");
-  });
+		assertEquals(path_to_root, "/1?key=a");
+		assertEquals(path_to_with_name, "/name/1?key=a");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep/1?key=a");
+		assertEquals(path_to_nested_with_parent_param, "/nested/1?parent-key=a");
+		assertEquals(
+			path_to_nested_deep__with_parent_param,
+			"/nested/1/deep/2?child-key=a"
+		);
+		assertEquals(path_to_root_with_falsy_param_value, "/0?key=a");
+	});
 
-  await t.step("boolean params and string query", () => {
-    const path_to_root = link("root", { param: true }, { key: "a" });
-    const path_to_with_name = link("with_name", { param: true }, { key: "a" });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link(
-      "nested/deep",
-      { "child-param": true },
-      { key: "a" },
-    );
-    const path_to_nested_with_parent_param = link(
-      "nested_with_parent_param",
-      { "parent-param": true },
-      { "parent-key": "a" },
-    );
-    const path_to_nested_deep_with_parent_param = link(
-      "nested_with_parent_param/deep",
-      { "parent-param": true, "child-param": false },
-      { "child-key": "a" },
-    );
+	await t.step("boolean params and string query", () => {
+		const path_to_root = link("root", { param: true }, { key: "a" });
+		const path_to_with_name = link("with_name", { param: true }, { key: "a" });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link(
+			"nested/deep",
+			{ "child-param": true },
+			{ key: "a" }
+		);
+		const path_to_nested_with_parent_param = link(
+			"nested_with_parent_param",
+			{ "parent-param": true },
+			{ "parent-key": "a" }
+		);
+		const path_to_nested_deep_with_parent_param = link(
+			"nested_with_parent_param/deep",
+			{ "parent-param": true, "child-param": false },
+			{ "child-key": "a" }
+		);
 
-    assertEquals(path_to_root, "/true?key=a");
-    assertEquals(path_to_with_name, "/name/true?key=a");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep/true?key=a");
-    assertEquals(path_to_nested_with_parent_param, "/nested/true?parent-key=a");
-    assertEquals(
-      path_to_nested_deep_with_parent_param,
-      "/nested/true/deep/false?child-key=a",
-    );
-  });
+		assertEquals(path_to_root, "/true?key=a");
+		assertEquals(path_to_with_name, "/name/true?key=a");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep/true?key=a");
+		assertEquals(path_to_nested_with_parent_param, "/nested/true?parent-key=a");
+		assertEquals(
+			path_to_nested_deep_with_parent_param,
+			"/nested/true/deep/false?child-key=a"
+		);
+	});
 
-  await t.step("string params and number query", () => {
-    const path_to_root = link("root", { param: "a" }, { key: 1 });
-    const path_to_with_name = link("with_name", { param: "a" }, { key: 1 });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link(
-      "nested/deep",
-      { "child-param": "a" },
-      { key: 1 },
-    );
-    const path_to_nested_with_parent_param = link(
-      "nested_with_parent_param",
-      { "parent-param": "a" },
-      { "parent-key": 1 },
-    );
-    const path_to_nested_deep_with_parent_param = link(
-      "nested_with_parent_param/deep",
-      { "parent-param": "a", "child-param": "b" },
-      { "child-key": 1 },
-    );
-    const path_to_root_with_falsy_query_value = link(
-      "root",
-      { param: "a" },
-      { key: 0 },
-    );
+	await t.step("string params and number query", () => {
+		const path_to_root = link("root", { param: "a" }, { key: 1 });
+		const path_to_with_name = link("with_name", { param: "a" }, { key: 1 });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link(
+			"nested/deep",
+			{ "child-param": "a" },
+			{ key: 1 }
+		);
+		const path_to_nested_with_parent_param = link(
+			"nested_with_parent_param",
+			{ "parent-param": "a" },
+			{ "parent-key": 1 }
+		);
+		const path_to_nested_deep_with_parent_param = link(
+			"nested_with_parent_param/deep",
+			{ "parent-param": "a", "child-param": "b" },
+			{ "child-key": 1 }
+		);
+		const path_to_root_with_falsy_query_value = link(
+			"root",
+			{ param: "a" },
+			{ key: 0 }
+		);
 
-    assertEquals(path_to_root, "/a?key=1");
-    assertEquals(path_to_with_name, "/name/a?key=1");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep/a?key=1");
-    assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=1");
-    assertEquals(
-      path_to_nested_deep_with_parent_param,
-      "/nested/a/deep/b?child-key=1",
-    );
-    assertEquals(path_to_root_with_falsy_query_value, "/a?key=0");
-  });
+		assertEquals(path_to_root, "/a?key=1");
+		assertEquals(path_to_with_name, "/name/a?key=1");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep/a?key=1");
+		assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=1");
+		assertEquals(
+			path_to_nested_deep_with_parent_param,
+			"/nested/a/deep/b?child-key=1"
+		);
+		assertEquals(path_to_root_with_falsy_query_value, "/a?key=0");
+	});
 
-  await t.step("string params and boolean query", () => {
-    const path_to_root = link("root", { param: "a" }, { key: true });
-    const path_to_with_name = link("with_name", { param: "a" }, { key: true });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link(
-      "nested/deep",
-      { "child-param": "a" },
-      { key: true },
-    );
-    const path_to_nested_with_parent_param = link(
-      "nested_with_parent_param",
-      { "parent-param": "a" },
-      { "parent-key": true },
-    );
-    const path_to_nested_deep_with_parent_param = link(
-      "nested_with_parent_param/deep",
-      { "parent-param": "a", "child-param": "b" },
-      { "child-key": true },
-    );
-    const path_to_root_with_falsy_query_value = link(
-      "root",
-      { param: "a" },
-      { key: false },
-    );
+	await t.step("string params and boolean query", () => {
+		const path_to_root = link("root", { param: "a" }, { key: true });
+		const path_to_with_name = link("with_name", { param: "a" }, { key: true });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link(
+			"nested/deep",
+			{ "child-param": "a" },
+			{ key: true }
+		);
+		const path_to_nested_with_parent_param = link(
+			"nested_with_parent_param",
+			{ "parent-param": "a" },
+			{ "parent-key": true }
+		);
+		const path_to_nested_deep_with_parent_param = link(
+			"nested_with_parent_param/deep",
+			{ "parent-param": "a", "child-param": "b" },
+			{ "child-key": true }
+		);
+		const path_to_root_with_falsy_query_value = link(
+			"root",
+			{ param: "a" },
+			{ key: false }
+		);
 
-    assertEquals(path_to_root, "/a?key=true");
-    assertEquals(path_to_with_name, "/name/a?key=true");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep/a?key=true");
-    assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=true");
-    assertEquals(
-      path_to_nested_deep_with_parent_param,
-      "/nested/a/deep/b?child-key=true",
-    );
-    assertEquals(path_to_root_with_falsy_query_value, "/a?key=false");
-  });
+		assertEquals(path_to_root, "/a?key=true");
+		assertEquals(path_to_with_name, "/name/a?key=true");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep/a?key=true");
+		assertEquals(path_to_nested_with_parent_param, "/nested/a?parent-key=true");
+		assertEquals(
+			path_to_nested_deep_with_parent_param,
+			"/nested/a/deep/b?child-key=true"
+		);
+		assertEquals(path_to_root_with_falsy_query_value, "/a?key=false");
+	});
 });

--- a/test/path_with_queries.test.ts
+++ b/test/path_with_queries.test.ts
@@ -1,231 +1,231 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-  create_link_generator,
-  type DefaultParamValue,
-  type ExtractRouteData,
-  type FlatRoutes,
-  flatten_route_config,
-  type RouteConfig,
+	create_link_generator,
+	type DefaultParamValue,
+	type ExtractRouteData,
+	type FlatRoutes,
+	flatten_route_config,
+	type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-  root: {
-    path: "/?key",
-  },
-  with_name: {
-    path: "/name?key",
-  },
-  nested: {
-    path: "/nested",
-    children: {
-      deep: {
-        path: "/deep?key",
-      },
-    },
-  },
-  nested_with_parent_param: {
-    path: "/nested?parent-key",
-    children: {
-      deep: {
-        path: "/deep?child-key",
-      },
-    },
-  },
-  multiple_query: {
-    path: "/?key1&key2",
-  },
+	root: {
+		path: "/?key",
+	},
+	with_name: {
+		path: "/name?key",
+	},
+	nested: {
+		path: "/nested",
+		children: {
+			deep: {
+				path: "/deep?key",
+			},
+		},
+	},
+	nested_with_parent_param: {
+		path: "/nested?parent-key",
+		children: {
+			deep: {
+				path: "/deep?child-key",
+			},
+		},
+	},
+	multiple_query: {
+		path: "/?key1&key2",
+	},
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-  type ExpectedFlatRoutes = {
-    root: "/?key";
-    with_name: "/name?key";
-    nested: "/nested";
-    "nested/deep": "/nested/deep?key";
-    nested_with_parent_param: "/nested?parent-key";
-    "nested_with_parent_param/deep": "/nested/deep?child-key";
-    multiple_query: "/?key1&key2";
-  };
+	type ExpectedFlatRoutes = {
+		root: "/?key";
+		with_name: "/name?key";
+		nested: "/nested";
+		"nested/deep": "/nested/deep?key";
+		nested_with_parent_param: "/nested?parent-key";
+		"nested_with_parent_param/deep": "/nested/deep?child-key";
+		multiple_query: "/?key1&key2";
+	};
 
-  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-    true,
-  );
+	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+		true
+	);
 });
 
 Deno.test("ExtractRouteData type", () => {
-  type ExpectedExtractRouteData = {
-    root: {
-      path: "/";
-      params: never;
-      queries: Partial<Record<"key", DefaultParamValue>>;
-    };
-    with_name: {
-      path: "/name";
-      params: never;
-      queries: Partial<Record<"key", DefaultParamValue>>;
-    };
-    nested: {
-      path: "/nested";
-      params: never;
-      queries: never;
-    };
-    "nested/deep": {
-      path: "/nested/deep";
-      params: never;
-      queries: Partial<Record<"key", DefaultParamValue>>;
-    };
-    nested_with_parent_param: {
-      path: "/nested";
-      params: never;
-      queries: Partial<Record<"parent-key", DefaultParamValue>>;
-    };
-    "nested_with_parent_param/deep": {
-      path: "/nested/deep";
-      params: never;
-      queries: Partial<Record<"child-key", DefaultParamValue>>;
-    };
-    multiple_query: {
-      path: "/";
-      params: never;
-      queries: Partial<
-        Record<"key1", DefaultParamValue> & Record<"key2", DefaultParamValue>
-      >;
-    };
-  };
+	type ExpectedExtractRouteData = {
+		root: {
+			path: "/";
+			params: never;
+			query: Partial<Record<"key", DefaultParamValue>>;
+		};
+		with_name: {
+			path: "/name";
+			params: never;
+			query: Partial<Record<"key", DefaultParamValue>>;
+		};
+		nested: {
+			path: "/nested";
+			params: never;
+			query: never;
+		};
+		"nested/deep": {
+			path: "/nested/deep";
+			params: never;
+			query: Partial<Record<"key", DefaultParamValue>>;
+		};
+		nested_with_parent_param: {
+			path: "/nested";
+			params: never;
+			query: Partial<Record<"parent-key", DefaultParamValue>>;
+		};
+		"nested_with_parent_param/deep": {
+			path: "/nested/deep";
+			params: never;
+			query: Partial<Record<"child-key", DefaultParamValue>>;
+		};
+		multiple_query: {
+			path: "/";
+			params: never;
+			query: Partial<
+				Record<"key1", DefaultParamValue> & Record<"key2", DefaultParamValue>
+			>;
+		};
+	};
 
-  assertType<
-    IsExact<
-      ExtractRouteData<typeof flat_route_config>,
-      ExpectedExtractRouteData
-    >
-  >(true);
+	assertType<
+		IsExact<
+			ExtractRouteData<typeof flat_route_config>,
+			ExpectedExtractRouteData
+		>
+	>(true);
 });
 
 Deno.test("flatten_route_config", () => {
-  const expected_flat_route_config = {
-    root: "/?key",
-    with_name: "/name?key",
-    nested: "/nested",
-    "nested/deep": "/nested/deep?key",
-    nested_with_parent_param: "/nested?parent-key",
-    "nested_with_parent_param/deep": "/nested/deep?child-key",
-    multiple_query: "/?key1&key2",
-  } as const satisfies FlatRoutes<typeof route_config>;
+	const expected_flat_route_config = {
+		root: "/?key",
+		with_name: "/name?key",
+		nested: "/nested",
+		"nested/deep": "/nested/deep?key",
+		nested_with_parent_param: "/nested?parent-key",
+		"nested_with_parent_param/deep": "/nested/deep?child-key",
+		multiple_query: "/?key1&key2",
+	} as const satisfies FlatRoutes<typeof route_config>;
 
-  assertEquals(flat_route_config, expected_flat_route_config);
+	assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", async (t) => {
-  const link = create_link_generator(flat_route_config);
+	const link = create_link_generator(flat_route_config);
 
-  await t.step("string param value", () => {
-    const path_to_root = link("root", undefined, { key: "a" });
-    const path_to_with_name = link("with_name", undefined, { key: "a" });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link("nested/deep", undefined, { key: "a" });
-    const path_to_nested_with_parent_param = link(
-      "nested_with_parent_param",
-      undefined,
-      { "parent-key": "a" },
-    );
-    const path_to_nested_deep_with_parent_query = link(
-      "nested_with_parent_param/deep",
-      undefined,
-      { "child-key": "a" },
-    );
-    assertEquals(path_to_root, "/?key=a");
-    assertEquals(path_to_with_name, "/name?key=a");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep?key=a");
-    assertEquals(path_to_nested_with_parent_param, "/nested?parent-key=a");
-    assertEquals(
-      path_to_nested_deep_with_parent_query,
-      "/nested/deep?child-key=a",
-    );
-  });
+	await t.step("string param value", () => {
+		const path_to_root = link("root", undefined, { key: "a" });
+		const path_to_with_name = link("with_name", undefined, { key: "a" });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link("nested/deep", undefined, { key: "a" });
+		const path_to_nested_with_parent_param = link(
+			"nested_with_parent_param",
+			undefined,
+			{ "parent-key": "a" }
+		);
+		const path_to_nested_deep_with_parent_query = link(
+			"nested_with_parent_param/deep",
+			undefined,
+			{ "child-key": "a" }
+		);
+		assertEquals(path_to_root, "/?key=a");
+		assertEquals(path_to_with_name, "/name?key=a");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep?key=a");
+		assertEquals(path_to_nested_with_parent_param, "/nested?parent-key=a");
+		assertEquals(
+			path_to_nested_deep_with_parent_query,
+			"/nested/deep?child-key=a"
+		);
+	});
 
-  await t.step("number param value", () => {
-    const path_to_root = link("root", undefined, { key: 1 });
-    const path_to_with_name = link("with_name", undefined, { key: 1 });
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link("nested/deep", undefined, { key: 1 });
-    const path_to_nested_with_parent_param = link(
-      "nested_with_parent_param",
-      undefined,
-      { "parent-key": 1 },
-    );
-    const path_to_nested_deep_with_parent_param = link(
-      "nested_with_parent_param/deep",
-      undefined,
-      { "child-key": 1 },
-    );
-    const path_to_root_with_falsy_param_value = link("root", undefined, {
-      key: 0,
-    });
+	await t.step("number param value", () => {
+		const path_to_root = link("root", undefined, { key: 1 });
+		const path_to_with_name = link("with_name", undefined, { key: 1 });
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link("nested/deep", undefined, { key: 1 });
+		const path_to_nested_with_parent_param = link(
+			"nested_with_parent_param",
+			undefined,
+			{ "parent-key": 1 }
+		);
+		const path_to_nested_deep_with_parent_param = link(
+			"nested_with_parent_param/deep",
+			undefined,
+			{ "child-key": 1 }
+		);
+		const path_to_root_with_falsy_param_value = link("root", undefined, {
+			key: 0,
+		});
 
-    assertEquals(path_to_root, "/?key=1");
-    assertEquals(path_to_with_name, "/name?key=1");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep?key=1");
-    assertEquals(path_to_nested_with_parent_param, "/nested?parent-key=1");
-    assertEquals(
-      path_to_nested_deep_with_parent_param,
-      "/nested/deep?child-key=1",
-    );
-    assertEquals(path_to_root_with_falsy_param_value, "/?key=0");
-  });
+		assertEquals(path_to_root, "/?key=1");
+		assertEquals(path_to_with_name, "/name?key=1");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep?key=1");
+		assertEquals(path_to_nested_with_parent_param, "/nested?parent-key=1");
+		assertEquals(
+			path_to_nested_deep_with_parent_param,
+			"/nested/deep?child-key=1"
+		);
+		assertEquals(path_to_root_with_falsy_param_value, "/?key=0");
+	});
 
-  await t.step(
-    "query is undefined, no query string should be generated",
-    () => {
-      const path_to_root = link("root", undefined, undefined);
-      const path_to_with_name = link("with_name", undefined, undefined);
-      const path_to_nested = link("nested");
-      const path_to_nested_deep = link("nested/deep", undefined, undefined);
-      const path_to_nested_with_parent_param = link(
-        "nested_with_parent_param",
-        undefined,
-        undefined,
-      );
-      const path_to_nested_deep_with_parent_param = link(
-        "nested_with_parent_param/deep",
-        undefined,
-        undefined,
-      );
-      assertEquals(path_to_root, "/");
-      assertEquals(path_to_with_name, "/name");
-      assertEquals(path_to_nested, "/nested");
-      assertEquals(path_to_nested_deep, "/nested/deep");
-      assertEquals(path_to_nested_with_parent_param, "/nested");
-      assertEquals(path_to_nested_deep_with_parent_param, "/nested/deep");
-    },
-  );
+	await t.step(
+		"query is undefined, no query string should be generated",
+		() => {
+			const path_to_root = link("root", undefined, undefined);
+			const path_to_with_name = link("with_name", undefined, undefined);
+			const path_to_nested = link("nested");
+			const path_to_nested_deep = link("nested/deep", undefined, undefined);
+			const path_to_nested_with_parent_param = link(
+				"nested_with_parent_param",
+				undefined,
+				undefined
+			);
+			const path_to_nested_deep_with_parent_param = link(
+				"nested_with_parent_param/deep",
+				undefined,
+				undefined
+			);
+			assertEquals(path_to_root, "/");
+			assertEquals(path_to_with_name, "/name");
+			assertEquals(path_to_nested, "/nested");
+			assertEquals(path_to_nested_deep, "/nested/deep");
+			assertEquals(path_to_nested_with_parent_param, "/nested");
+			assertEquals(path_to_nested_deep_with_parent_param, "/nested/deep");
+		}
+	);
 
-  await t.step("queries should be optional when generating paths", () => {
-    const path_to_root = link("root");
-    const path_to_with_name = link("with_name");
-    const path_to_nested = link("nested");
-    const path_to_nested_deep = link("nested/deep");
-    const path_to_nested_with_parent_param = link("nested_with_parent_param");
-    const path_to_nested_deep_with_parent_param = link(
-      "nested_with_parent_param/deep",
-    );
-    assertEquals(path_to_root, "/");
-    assertEquals(path_to_with_name, "/name");
-    assertEquals(path_to_nested, "/nested");
-    assertEquals(path_to_nested_deep, "/nested/deep");
-    assertEquals(path_to_nested_with_parent_param, "/nested");
-    assertEquals(path_to_nested_deep_with_parent_param, "/nested/deep");
-  });
+	await t.step("query should be optional when generating paths", () => {
+		const path_to_root = link("root");
+		const path_to_with_name = link("with_name");
+		const path_to_nested = link("nested");
+		const path_to_nested_deep = link("nested/deep");
+		const path_to_nested_with_parent_param = link("nested_with_parent_param");
+		const path_to_nested_deep_with_parent_param = link(
+			"nested_with_parent_param/deep"
+		);
+		assertEquals(path_to_root, "/");
+		assertEquals(path_to_with_name, "/name");
+		assertEquals(path_to_nested, "/nested");
+		assertEquals(path_to_nested_deep, "/nested/deep");
+		assertEquals(path_to_nested_with_parent_param, "/nested");
+		assertEquals(path_to_nested_deep_with_parent_param, "/nested/deep");
+	});
 
-  await t.step("multiple query", () => {
-    const path_to_multiple_query = link("multiple_query", undefined, {
-      key1: "a",
-      key2: "b",
-    });
-    assertEquals(path_to_multiple_query, "/?key1=a&key2=b");
-  });
+	await t.step("multiple query", () => {
+		const path_to_multiple_query = link("multiple_query", undefined, {
+			key1: "a",
+			key2: "b",
+		});
+		assertEquals(path_to_multiple_query, "/?key1=a&key2=b");
+	});
 });

--- a/test/path_with_queries.test.ts
+++ b/test/path_with_queries.test.ts
@@ -1,231 +1,231 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertType, type IsExact } from "@std/testing/types";
 import {
-	create_link_generator,
-	type DefaultParamValue,
-	type ExtractRouteData,
-	type FlatRoutes,
-	flatten_route_config,
-	type RouteConfig,
+  create_link_generator,
+  type DefaultParamValue,
+  type ExtractRouteData,
+  type FlatRoutes,
+  flatten_route_config,
+  type RouteConfig,
 } from "../src/mod.ts";
 
 const route_config = {
-	root: {
-		path: "/?key",
-	},
-	with_name: {
-		path: "/name?key",
-	},
-	nested: {
-		path: "/nested",
-		children: {
-			deep: {
-				path: "/deep?key",
-			},
-		},
-	},
-	nested_with_parent_param: {
-		path: "/nested?parent-key",
-		children: {
-			deep: {
-				path: "/deep?child-key",
-			},
-		},
-	},
-	multiple_query: {
-		path: "/?key1&key2",
-	},
+  root: {
+    path: "/?key",
+  },
+  with_name: {
+    path: "/name?key",
+  },
+  nested: {
+    path: "/nested",
+    children: {
+      deep: {
+        path: "/deep?key",
+      },
+    },
+  },
+  nested_with_parent_param: {
+    path: "/nested?parent-key",
+    children: {
+      deep: {
+        path: "/deep?child-key",
+      },
+    },
+  },
+  multiple_query: {
+    path: "/?key1&key2",
+  },
 } as const satisfies RouteConfig;
 
 const flat_route_config = flatten_route_config(route_config);
 
 Deno.test("FlatRoutes type", () => {
-	type ExpectedFlatRoutes = {
-		root: "/?key";
-		with_name: "/name?key";
-		nested: "/nested";
-		"nested/deep": "/nested/deep?key";
-		nested_with_parent_param: "/nested?parent-key";
-		"nested_with_parent_param/deep": "/nested/deep?child-key";
-		multiple_query: "/?key1&key2";
-	};
+  type ExpectedFlatRoutes = {
+    root: "/?key";
+    with_name: "/name?key";
+    nested: "/nested";
+    "nested/deep": "/nested/deep?key";
+    nested_with_parent_param: "/nested?parent-key";
+    "nested_with_parent_param/deep": "/nested/deep?child-key";
+    multiple_query: "/?key1&key2";
+  };
 
-	assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
-		true
-	);
+  assertType<IsExact<FlatRoutes<typeof route_config>, ExpectedFlatRoutes>>(
+    true,
+  );
 });
 
 Deno.test("ExtractRouteData type", () => {
-	type ExpectedExtractRouteData = {
-		root: {
-			path: "/";
-			params: never;
-			query: Partial<Record<"key", DefaultParamValue>>;
-		};
-		with_name: {
-			path: "/name";
-			params: never;
-			query: Partial<Record<"key", DefaultParamValue>>;
-		};
-		nested: {
-			path: "/nested";
-			params: never;
-			query: never;
-		};
-		"nested/deep": {
-			path: "/nested/deep";
-			params: never;
-			query: Partial<Record<"key", DefaultParamValue>>;
-		};
-		nested_with_parent_param: {
-			path: "/nested";
-			params: never;
-			query: Partial<Record<"parent-key", DefaultParamValue>>;
-		};
-		"nested_with_parent_param/deep": {
-			path: "/nested/deep";
-			params: never;
-			query: Partial<Record<"child-key", DefaultParamValue>>;
-		};
-		multiple_query: {
-			path: "/";
-			params: never;
-			query: Partial<
-				Record<"key1", DefaultParamValue> & Record<"key2", DefaultParamValue>
-			>;
-		};
-	};
+  type ExpectedExtractRouteData = {
+    root: {
+      path: "/";
+      params: never;
+      query: Partial<Record<"key", DefaultParamValue>>;
+    };
+    with_name: {
+      path: "/name";
+      params: never;
+      query: Partial<Record<"key", DefaultParamValue>>;
+    };
+    nested: {
+      path: "/nested";
+      params: never;
+      query: never;
+    };
+    "nested/deep": {
+      path: "/nested/deep";
+      params: never;
+      query: Partial<Record<"key", DefaultParamValue>>;
+    };
+    nested_with_parent_param: {
+      path: "/nested";
+      params: never;
+      query: Partial<Record<"parent-key", DefaultParamValue>>;
+    };
+    "nested_with_parent_param/deep": {
+      path: "/nested/deep";
+      params: never;
+      query: Partial<Record<"child-key", DefaultParamValue>>;
+    };
+    multiple_query: {
+      path: "/";
+      params: never;
+      query: Partial<
+        Record<"key1", DefaultParamValue> & Record<"key2", DefaultParamValue>
+      >;
+    };
+  };
 
-	assertType<
-		IsExact<
-			ExtractRouteData<typeof flat_route_config>,
-			ExpectedExtractRouteData
-		>
-	>(true);
+  assertType<
+    IsExact<
+      ExtractRouteData<typeof flat_route_config>,
+      ExpectedExtractRouteData
+    >
+  >(true);
 });
 
 Deno.test("flatten_route_config", () => {
-	const expected_flat_route_config = {
-		root: "/?key",
-		with_name: "/name?key",
-		nested: "/nested",
-		"nested/deep": "/nested/deep?key",
-		nested_with_parent_param: "/nested?parent-key",
-		"nested_with_parent_param/deep": "/nested/deep?child-key",
-		multiple_query: "/?key1&key2",
-	} as const satisfies FlatRoutes<typeof route_config>;
+  const expected_flat_route_config = {
+    root: "/?key",
+    with_name: "/name?key",
+    nested: "/nested",
+    "nested/deep": "/nested/deep?key",
+    nested_with_parent_param: "/nested?parent-key",
+    "nested_with_parent_param/deep": "/nested/deep?child-key",
+    multiple_query: "/?key1&key2",
+  } as const satisfies FlatRoutes<typeof route_config>;
 
-	assertEquals(flat_route_config, expected_flat_route_config);
+  assertEquals(flat_route_config, expected_flat_route_config);
 });
 
 Deno.test("create_link_generator", async (t) => {
-	const link = create_link_generator(flat_route_config);
+  const link = create_link_generator(flat_route_config);
 
-	await t.step("string param value", () => {
-		const path_to_root = link("root", undefined, { key: "a" });
-		const path_to_with_name = link("with_name", undefined, { key: "a" });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link("nested/deep", undefined, { key: "a" });
-		const path_to_nested_with_parent_param = link(
-			"nested_with_parent_param",
-			undefined,
-			{ "parent-key": "a" }
-		);
-		const path_to_nested_deep_with_parent_query = link(
-			"nested_with_parent_param/deep",
-			undefined,
-			{ "child-key": "a" }
-		);
-		assertEquals(path_to_root, "/?key=a");
-		assertEquals(path_to_with_name, "/name?key=a");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep?key=a");
-		assertEquals(path_to_nested_with_parent_param, "/nested?parent-key=a");
-		assertEquals(
-			path_to_nested_deep_with_parent_query,
-			"/nested/deep?child-key=a"
-		);
-	});
+  await t.step("string param value", () => {
+    const path_to_root = link("root", undefined, { key: "a" });
+    const path_to_with_name = link("with_name", undefined, { key: "a" });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link("nested/deep", undefined, { key: "a" });
+    const path_to_nested_with_parent_param = link(
+      "nested_with_parent_param",
+      undefined,
+      { "parent-key": "a" },
+    );
+    const path_to_nested_deep_with_parent_query = link(
+      "nested_with_parent_param/deep",
+      undefined,
+      { "child-key": "a" },
+    );
+    assertEquals(path_to_root, "/?key=a");
+    assertEquals(path_to_with_name, "/name?key=a");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep?key=a");
+    assertEquals(path_to_nested_with_parent_param, "/nested?parent-key=a");
+    assertEquals(
+      path_to_nested_deep_with_parent_query,
+      "/nested/deep?child-key=a",
+    );
+  });
 
-	await t.step("number param value", () => {
-		const path_to_root = link("root", undefined, { key: 1 });
-		const path_to_with_name = link("with_name", undefined, { key: 1 });
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link("nested/deep", undefined, { key: 1 });
-		const path_to_nested_with_parent_param = link(
-			"nested_with_parent_param",
-			undefined,
-			{ "parent-key": 1 }
-		);
-		const path_to_nested_deep_with_parent_param = link(
-			"nested_with_parent_param/deep",
-			undefined,
-			{ "child-key": 1 }
-		);
-		const path_to_root_with_falsy_param_value = link("root", undefined, {
-			key: 0,
-		});
+  await t.step("number param value", () => {
+    const path_to_root = link("root", undefined, { key: 1 });
+    const path_to_with_name = link("with_name", undefined, { key: 1 });
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link("nested/deep", undefined, { key: 1 });
+    const path_to_nested_with_parent_param = link(
+      "nested_with_parent_param",
+      undefined,
+      { "parent-key": 1 },
+    );
+    const path_to_nested_deep_with_parent_param = link(
+      "nested_with_parent_param/deep",
+      undefined,
+      { "child-key": 1 },
+    );
+    const path_to_root_with_falsy_param_value = link("root", undefined, {
+      key: 0,
+    });
 
-		assertEquals(path_to_root, "/?key=1");
-		assertEquals(path_to_with_name, "/name?key=1");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep?key=1");
-		assertEquals(path_to_nested_with_parent_param, "/nested?parent-key=1");
-		assertEquals(
-			path_to_nested_deep_with_parent_param,
-			"/nested/deep?child-key=1"
-		);
-		assertEquals(path_to_root_with_falsy_param_value, "/?key=0");
-	});
+    assertEquals(path_to_root, "/?key=1");
+    assertEquals(path_to_with_name, "/name?key=1");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep?key=1");
+    assertEquals(path_to_nested_with_parent_param, "/nested?parent-key=1");
+    assertEquals(
+      path_to_nested_deep_with_parent_param,
+      "/nested/deep?child-key=1",
+    );
+    assertEquals(path_to_root_with_falsy_param_value, "/?key=0");
+  });
 
-	await t.step(
-		"query is undefined, no query string should be generated",
-		() => {
-			const path_to_root = link("root", undefined, undefined);
-			const path_to_with_name = link("with_name", undefined, undefined);
-			const path_to_nested = link("nested");
-			const path_to_nested_deep = link("nested/deep", undefined, undefined);
-			const path_to_nested_with_parent_param = link(
-				"nested_with_parent_param",
-				undefined,
-				undefined
-			);
-			const path_to_nested_deep_with_parent_param = link(
-				"nested_with_parent_param/deep",
-				undefined,
-				undefined
-			);
-			assertEquals(path_to_root, "/");
-			assertEquals(path_to_with_name, "/name");
-			assertEquals(path_to_nested, "/nested");
-			assertEquals(path_to_nested_deep, "/nested/deep");
-			assertEquals(path_to_nested_with_parent_param, "/nested");
-			assertEquals(path_to_nested_deep_with_parent_param, "/nested/deep");
-		}
-	);
+  await t.step(
+    "query is undefined, no query string should be generated",
+    () => {
+      const path_to_root = link("root", undefined, undefined);
+      const path_to_with_name = link("with_name", undefined, undefined);
+      const path_to_nested = link("nested");
+      const path_to_nested_deep = link("nested/deep", undefined, undefined);
+      const path_to_nested_with_parent_param = link(
+        "nested_with_parent_param",
+        undefined,
+        undefined,
+      );
+      const path_to_nested_deep_with_parent_param = link(
+        "nested_with_parent_param/deep",
+        undefined,
+        undefined,
+      );
+      assertEquals(path_to_root, "/");
+      assertEquals(path_to_with_name, "/name");
+      assertEquals(path_to_nested, "/nested");
+      assertEquals(path_to_nested_deep, "/nested/deep");
+      assertEquals(path_to_nested_with_parent_param, "/nested");
+      assertEquals(path_to_nested_deep_with_parent_param, "/nested/deep");
+    },
+  );
 
-	await t.step("query should be optional when generating paths", () => {
-		const path_to_root = link("root");
-		const path_to_with_name = link("with_name");
-		const path_to_nested = link("nested");
-		const path_to_nested_deep = link("nested/deep");
-		const path_to_nested_with_parent_param = link("nested_with_parent_param");
-		const path_to_nested_deep_with_parent_param = link(
-			"nested_with_parent_param/deep"
-		);
-		assertEquals(path_to_root, "/");
-		assertEquals(path_to_with_name, "/name");
-		assertEquals(path_to_nested, "/nested");
-		assertEquals(path_to_nested_deep, "/nested/deep");
-		assertEquals(path_to_nested_with_parent_param, "/nested");
-		assertEquals(path_to_nested_deep_with_parent_param, "/nested/deep");
-	});
+  await t.step("query should be optional when generating paths", () => {
+    const path_to_root = link("root");
+    const path_to_with_name = link("with_name");
+    const path_to_nested = link("nested");
+    const path_to_nested_deep = link("nested/deep");
+    const path_to_nested_with_parent_param = link("nested_with_parent_param");
+    const path_to_nested_deep_with_parent_param = link(
+      "nested_with_parent_param/deep",
+    );
+    assertEquals(path_to_root, "/");
+    assertEquals(path_to_with_name, "/name");
+    assertEquals(path_to_nested, "/nested");
+    assertEquals(path_to_nested_deep, "/nested/deep");
+    assertEquals(path_to_nested_with_parent_param, "/nested");
+    assertEquals(path_to_nested_deep_with_parent_param, "/nested/deep");
+  });
 
-	await t.step("multiple query", () => {
-		const path_to_multiple_query = link("multiple_query", undefined, {
-			key1: "a",
-			key2: "b",
-		});
-		assertEquals(path_to_multiple_query, "/?key1=a&key2=b");
-	});
+  await t.step("multiple query", () => {
+    const path_to_multiple_query = link("multiple_query", undefined, {
+      key1: "a",
+      key2: "b",
+    });
+    assertEquals(path_to_multiple_query, "/?key1=a&key2=b");
+  });
 });


### PR DESCRIPTION
In a previous pull request, I renamed the query property of the `ExtractRouteData` type to queries, in order to make the naming more consistent by pluralizing it like `params`. However, many frameworks and libraries use `req.query`, so I decided to revert it.